### PR TITLE
Herstel alias verwerking voor enkelvoudige `use` statements

### DIFF
--- a/src/UseStatementSimplifierSurgical.php
+++ b/src/UseStatementSimplifierSurgical.php
@@ -3,6 +3,7 @@
 namespace HenkPoley\DocBlockDoctor;
 
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\PrettyPrinter;
 
@@ -40,9 +41,12 @@ class UseStatementSimplifierSurgical extends NodeVisitorAbstract
             // Construct the new single UseUse node
             $newNameParts = array_merge($node->prefix->getParts(), $originalUse->name->getParts());
             $newUseName = new Node\Name($newNameParts, $originalUse->name->getAttributes());
+            $aliasNode = $originalUse->alias instanceof Identifier
+                ? clone $originalUse->alias
+                : null;
             $newUseUse = new Node\Stmt\UseUse(
                 $newUseName,
-                $originalUse->alias->name ?? null, // alias is Identifier or null
+                $aliasNode,
                 $originalUse->type,
                 $originalUse->getAttributes() // Carry over attributes from UseUse
             );


### PR DESCRIPTION
## Samenvatting
- importeer `Identifier` in de UseStatementSimplifierSurgical
- kloon de alias wanneer een GroupUse wordt omgezet naar een enkelvoudige use-statement

## Testen
- `php` is niet beschikbaar dus er is geen syntactische controle uitgevoerd

------
https://chatgpt.com/codex/tasks/task_e_683f476b5a2883288cb76cf5d7b37452