### PR TITLE
Fix unreachable call handling

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -196,6 +196,9 @@ class Application
                     );
 
                     foreach ($callNodes as $callNode) {
+                        if ($astUtils->isNodeAfterExecutionEndingStmt($callNode, $funcNode)) {
+                            continue;
+                        }
                         $calleeKey = $astUtils->getCalleeKey($callNode, $callerNamespace, $callerUseMap, $funcNode);
                         if ($calleeKey && $calleeKey !== $funcKey) {
                             $exceptionsFromCallee = GlobalCache::$resolvedThrows[$calleeKey] ?? [];

--- a/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
+++ b/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
@@ -88,6 +88,9 @@ class ThrowsResolutionIntegrationTest extends TestCase
                             // assume all exceptions from this call are caught
                             continue;
                         }
+                        if ($utils->isNodeAfterExecutionEndingStmt($call, $node)) {
+                            continue;
+                        }
                         $calleeKey = null;
                         if (
                             $call instanceof \PhpParser\Node\Expr\MethodCall &&

--- a/tests/fixtures/throw-ends-execution/ThrowEndsExecution.php
+++ b/tests/fixtures/throw-ends-execution/ThrowEndsExecution.php
@@ -1,0 +1,22 @@
+<?php
+// tests/fixtures/throw-ends-execution/ThrowEndsExecution.php
+namespace Pitfalls\ThrowEndsExecution;
+
+class Helper {
+    public function boom(): void {
+        throw new \RuntimeException('fail');
+    }
+}
+
+class Runner {
+    public function run(): void {
+        throw new \LogicException('stop');
+        (new Helper())->boom();
+    }
+}
+
+class Caller {
+    public function call(): void {
+        (new Runner())->run();
+    }
+}

--- a/tests/fixtures/throw-ends-execution/expected_results.json
+++ b/tests/fixtures/throw-ends-execution/expected_results.json
@@ -1,0 +1,13 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\ThrowEndsExecution\\Helper::boom": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\ThrowEndsExecution\\Runner::run": [
+      "LogicException"
+    ],
+    "Pitfalls\\ThrowEndsExecution\\Caller::call": [
+      "LogicException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- ensure calls after an unconditional `throw` are ignored
- expose `isNodeAfterExecutionEndingStmt()` in `AstUtils`
- skip unreachable calls when resolving throws
- cover behaviour with new `throw-ends-execution` fixture
- remove unintended `composer.lock`

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_683ff7ad6e3483289014f7fb1bca064f