### PR TITLE
Fix unreachable throw detection

### DIFF
--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -186,6 +186,11 @@ class ThrowsGatherer extends NodeVisitorAbstract
         }
         $throwNodes = $this->nodeFinder->findInstanceOf($funcOrMethodNode->stmts, Node\Expr\Throw_::class);
         foreach ($throwNodes as $throwExpr) {
+            // Skip throws that are unreachable due to a prior throw/return
+            // statement in the current statement list.
+            if ($this->astUtils->isNodeAfterExecutionEndingStmt($throwExpr, $funcOrMethodNode)) {
+                continue;
+            }
             if ($throwExpr->expr instanceof Node\Expr\New_) {
                 $newExpr = $throwExpr->expr;
                 if ($newExpr->class instanceof Node\Name) {


### PR DESCRIPTION
## Summary
- skip throw statements occurring after an earlier throw or return
- ensure unreachable throws no longer affect collected throws

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_683ffd96bd148328adb786a11a344de0