### PR TITLE
Add constructor property promotion support

### DIFF
--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -172,4 +172,50 @@ class AstUtilsTest extends TestCase
         $resolved = $this->astUtils->getCalleeKey($calls[0], 'TestNS', [], $createme);
         $this->assertSame('TestNS\\B::bar', $resolved);
     }
+
+    public function testResolvePromotedPropertyCall(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace P; 
+
+        class Q {
+            public function __construct(private R $r) {}
+
+            public function foo(): void {
+                $this->r->bar();
+            }
+        }
+
+        class R { public function bar(): void {} }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $foo = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'foo');
+        $this->assertNotNull($foo);
+        $call = $this->finder->findFirstInstanceOf($foo->stmts, Node\Expr\MethodCall::class);
+        $resolved = $this->astUtils->getCalleeKey($call, 'P', [], $foo);
+        $this->assertSame('P\\R::bar', $resolved);
+    }
 }

--- a/tests/fixtures/constructor-property-promotion/Template.php
+++ b/tests/fixtures/constructor-property-promotion/Template.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Pitfalls\ConstructorPropertyPromotion;
+
+class Template
+{
+    public function __construct(private Translate $translator)
+    {
+    }
+
+    public function getEntityPropertyTranslation(): void
+    {
+        $tryLanguages = $this->translator->getLanguage()->getPreferredLanguages();
+    }
+}
+
+class Translate
+{
+    private Language $language;
+
+    public function __construct()
+    {
+        $this->language = new Language();
+    }
+
+    public function getLanguage(): Language
+    {
+        return $this->language;
+    }
+}
+
+class Language
+{
+    /**
+     * @throws \ArithmeticError
+     * @return array
+     */
+    public function getPreferredLanguages(): array
+    {
+        throw new \ArithmeticError();
+    }
+}

--- a/tests/fixtures/constructor-property-promotion/expected_results.json
+++ b/tests/fixtures/constructor-property-promotion/expected_results.json
@@ -1,0 +1,7 @@
+{
+  "fullyQualifiedMethodKeys" :{
+    "Pitfalls\\ConstructorPropertyPromotion\\Template::getEntityPropertyTranslation": [
+      "ArithmeticError"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- handle promoted constructor properties when resolving method call types
- add unit test for promoted property
- add fixture demonstrating property promotion

## Testing
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684113a0aa148328831ff89a89b1d13b