### PR TITLE
Fix trait property resolution in AstUtils

### DIFF
--- a/src/AstUtils.php
+++ b/src/AstUtils.php
@@ -231,18 +231,17 @@ class AstUtils
             // The method name, e.g. "getLanguage"
             $methodName = $callNode->name->toString();
 
-            // Walk up from the current method/function node to find the enclosing Class_ node.
+            // Walk up from the current method/function node to find the enclosing Class_ or Trait_ node.
             $parent = $callerFuncOrMethodNode;
-            while ($parent !== null && !($parent instanceof Class_)) {
+            while ($parent !== null && !($parent instanceof Class_ || $parent instanceof Node\Stmt\Trait_)) {
                 $parent = $parent->getAttribute('parent');
             }
 
-            if ($parent instanceof Class_) {
-                /** @var Class_ $classNode */
+            if ($parent instanceof Class_ || $parent instanceof Node\Stmt\Trait_) {
+                /** @var Class_|Node\Stmt\Trait_ $classNode */
                 $classNode = $parent;
 
-            }
-                // Look through all properties of this class to find one named `$propertyName`
+                // Look through all properties of this class/trait to find one named `$propertyName`
                 foreach ($classNode->stmts as $stmt) {
                     if (!($stmt instanceof Node\Stmt\Property)) {
                         continue;
@@ -327,6 +326,7 @@ class AstUtils
                         }
                     }
                 }
+            }
             // If we didn’t find a matching @var or couldn’t resolve it, fall through:
         }
 

--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -218,4 +218,50 @@ class AstUtilsTest extends TestCase
         $resolved = $this->astUtils->getCalleeKey($call, 'P', [], $foo);
         $this->assertSame('P\\R::bar', $resolved);
     }
+
+    public function testResolveTraitPropertyCall(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace T;
+
+        trait Tr {
+            private U $u;
+
+            public function foo(): void {
+                $this->u->bar();
+            }
+        }
+
+        class U { public function bar(): void {} }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $foo = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'foo');
+        $this->assertNotNull($foo);
+        $call = $this->finder->findFirstInstanceOf($foo->stmts, Node\Expr\MethodCall::class);
+        $resolved = $this->astUtils->getCalleeKey($call, 'T', [], $foo);
+        $this->assertSame('T\\U::bar', $resolved);
+    }
 }


### PR DESCRIPTION
## Summary
- fix undefined variable when resolving method calls on `$this->prop` in traits
- support trait properties in `getCalleeKey`
- add regression test for trait property resolution

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/psalm --no-cache` *(fails: Psalm requires PHP >= 8.3.16)*

------
https://chatgpt.com/codex/tasks/task_e_68411d7897e0832883dae34eb2b7eb1b