### PR TITLE
Move example classes to test fixtures

### DIFF
--- a/tests/fixtures/example-classes/Example.php
+++ b/tests/fixtures/example-classes/Example.php
@@ -1,11 +1,11 @@
 <?php
 
-// src/Example.php
-namespace HenkPoley\DocBlockDoctor;
+// tests/fixtures/example-classes/Example.php
+namespace HenkPoley\DocBlockDoctor\TestFixtures\ExampleClasses;
 
 use Exception;
-use HenkPoley\DocBlockDoctor\SubPath\OneMoreClass;
-use HenkPoley\DocBlockDoctor\SubPath\ThirdExampleClass;
+use HenkPoley\DocBlockDoctor\TestFixtures\ExampleClasses\SubPath\OneMoreClass;
+use HenkPoley\DocBlockDoctor\TestFixtures\ExampleClasses\SubPath\ThirdExampleClass;
 use LogicException;
 
 class Example

--- a/tests/fixtures/example-classes/SubPath/ClassThatThowsOnInstatiation.php
+++ b/tests/fixtures/example-classes/SubPath/ClassThatThowsOnInstatiation.php
@@ -1,6 +1,7 @@
 <?php
 
-namespace HenkPoley\DocBlockDoctor\SubPath;
+// tests/fixtures/example-classes/SubPath/ClassThatThowsOnInstatiation.php
+namespace HenkPoley\DocBlockDoctor\TestFixtures\ExampleClasses\SubPath;
 
 class ClassThatThowsOnInstatiation
 {

--- a/tests/fixtures/example-classes/SubPath/OneMoreClass.php
+++ b/tests/fixtures/example-classes/SubPath/OneMoreClass.php
@@ -1,6 +1,7 @@
 <?php
 
-namespace HenkPoley\DocBlockDoctor\SubPath;
+// tests/fixtures/example-classes/SubPath/OneMoreClass.php
+namespace HenkPoley\DocBlockDoctor\TestFixtures\ExampleClasses\SubPath;
 
 class OneMoreClass
 {
@@ -21,7 +22,7 @@ class OneMoreClass
     }
 
     /** Does not throw any exception by itself */
-    public function nonStaticFunction(): \HenkPoley\DocBlockDoctor\SubPath\ThirdExampleClass {
+    public function nonStaticFunction(): \HenkPoley\DocBlockDoctor\TestFixtures\ExampleClasses\SubPath\ThirdExampleClass {
         return new ThirdExampleClass();
     }
 

--- a/tests/fixtures/example-classes/SubPath/ThirdExampleClass.php
+++ b/tests/fixtures/example-classes/SubPath/ThirdExampleClass.php
@@ -1,6 +1,7 @@
 <?php
 
-namespace HenkPoley\DocBlockDoctor\SubPath;
+// tests/fixtures/example-classes/SubPath/ThirdExampleClass.php
+namespace HenkPoley\DocBlockDoctor\TestFixtures\ExampleClasses\SubPath;
 
 class ThirdExampleClass
 {

--- a/tests/fixtures/example-classes/expected_results.json
+++ b/tests/fixtures/example-classes/expected_results.json
@@ -1,0 +1,47 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\Example::one": [
+      "Exception",
+      "LogicException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\Example::two": [
+      "LogicException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\Example::three": [
+      "Exception"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\Example::usesFunctionOnObjectReturnedFromCallToClassVariable": [
+      "ErrorException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\Example::usesFunctionOnClassVariable": [
+      "UnderflowException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\Example::functionVariable": [
+      "UnderflowException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\Example::callOnNewObject": [
+      "ErrorException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\Example::surelyThisReturnsAnObject": [],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\Example::weTrustReturnAnnotations": [],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\SubPath\\ClassThatThowsOnInstatiation::__construct": [
+      "BadMethodCallException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\SubPath\\ClassThatThowsOnInstatiation::instantiateSelf": [
+      "BadMethodCallException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\SubPath\\OneMoreClass::aFunction": [
+      "LogicException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\SubPath\\OneMoreClass::bFunction": [
+      "LogicException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\SubPath\\OneMoreClass::nonStaticFunction": [],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\SubPath\\OneMoreClass::nonStaticFunctionThatThrows": [
+      "UnderflowException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ExampleClasses\\SubPath\\ThirdExampleClass::someOtherNonStaticFunction": [
+      "ErrorException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- relocate `src/Example.php` and related classes into a new `example-classes` fixture
- update namespaces in the moved files
- add expected results for the new fixture

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6841896ed4fc8328bc5255fbb8087663