### PR TITLE
Add CLI options for read/write directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ Add to your `composer.json`:
 ## Commandline syntax
 
 ```shell
-php ./vendor/bin/doc-block-doctor <path>
+php ./vendor/bin/doc-block-doctor [options] <path>
+
+Options:
+  --read-dirs=DIRS   Comma-separated list of directories to read when gathering info (default: src,tests)
+  --write-dirs=DIRS  Comma-separated list of directories that may be modified (default: src)
 ```
 
 ## Result

--- a/tests/fixtures/anonymous-class-property/Client.php
+++ b/tests/fixtures/anonymous-class-property/Client.php
@@ -1,0 +1,3 @@
+<?php
+namespace HenkPoley\DocBlockDoctor\TestFixtures\AnonymousClassProperty;
+class Client {}

--- a/tests/fixtures/anonymous-class-property/Configuration.php
+++ b/tests/fixtures/anonymous-class-property/Configuration.php
@@ -1,0 +1,3 @@
+<?php
+namespace HenkPoley\DocBlockDoctor\TestFixtures\AnonymousClassProperty;
+class Configuration {}

--- a/tests/fixtures/anonymous-class-property/RedisStoreTest.php
+++ b/tests/fixtures/anonymous-class-property/RedisStoreTest.php
@@ -1,0 +1,21 @@
+<?php
+namespace HenkPoley\DocBlockDoctor\TestFixtures\AnonymousClassProperty;
+
+use HenkPoley\DocBlockDoctor\TestFixtures\AnonymousClassProperty\{Configuration, Store};
+use HenkPoley\DocBlockDoctor\TestFixtures\AnonymousClassProperty\Store\RedisStore;
+
+class RedisStoreTest
+{
+    protected Client $client;
+    protected RedisStore $store;
+    protected array $config;
+
+    protected function setUp(): void
+    {
+        $this->config = [];
+        $this->client = new class ($this) extends Client {
+            public function __construct(protected RedisStoreTest $unitTest) {}
+        };
+        $this->store = new Store\RedisStore($this->client);
+    }
+}

--- a/tests/fixtures/anonymous-class-property/Store/RedisStore.php
+++ b/tests/fixtures/anonymous-class-property/Store/RedisStore.php
@@ -1,0 +1,15 @@
+<?php
+namespace HenkPoley\DocBlockDoctor\TestFixtures\AnonymousClassProperty\Store;
+
+use HenkPoley\DocBlockDoctor\TestFixtures\AnonymousClassProperty\Client;
+
+class RedisStore
+{
+    /**
+     * @throws \RuntimeException
+     */
+    public function __construct(Client $client)
+    {
+        throw new \RuntimeException();
+    }
+}

--- a/tests/fixtures/anonymous-class-property/expected_results.json
+++ b/tests/fixtures/anonymous-class-property/expected_results.json
@@ -1,0 +1,10 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\AnonymousClassProperty\\Store\\RedisStore::__construct": [
+      "RuntimeException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\AnonymousClassProperty\\RedisStoreTest::setUp": [
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add `--read-dirs` and `--write-dirs` options
- default to reading from `src` and `tests` and only modifying `src`
- document new options in README

## Testing
- `./vendor/bin/phpunit --stop-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6841af0a9bb4832899f2383b292e2f9f