### PR TITLE
Fix autoloading side effects

### DIFF
--- a/src/DocBlockUpdater.php
+++ b/src/DocBlockUpdater.php
@@ -4,6 +4,7 @@ namespace HenkPoley\DocBlockDoctor;
 
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Node;
+use HenkPoley\DocBlockDoctor\AstUtils;
 
 class DocBlockUpdater extends NodeVisitorAbstract
 {
@@ -109,7 +110,7 @@ class DocBlockUpdater extends NodeVisitorAbstract
         // Filter out any classes or interfaces that don’t actually exist
         $analyzedThrowsFqcns = array_filter(
             $analyzedThrowsFqcns,
-            static fn(string $fqcn): bool => class_exists($fqcn) || interface_exists($fqcn)
+            static fn(string $fqcn): bool => AstUtils::classOrInterfaceExistsNoAutoload($fqcn)
         );
         $analyzedThrowsFqcns = array_values($analyzedThrowsFqcns);
         sort($analyzedThrowsFqcns);

--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -7,6 +7,7 @@ use PhpParser\NodeFinder;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
+use HenkPoley\DocBlockDoctor\AstUtils;
 
 class ThrowsGatherer extends NodeVisitorAbstract
 {
@@ -235,7 +236,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
         }
         $filtered = array_filter(
             $fqcns,
-            static fn(string $fqcn): bool => class_exists($fqcn) || interface_exists($fqcn)
+            static fn(string $fqcn): bool => AstUtils::classOrInterfaceExistsNoAutoload($fqcn)
         );
         return array_values(array_unique($filtered));
     }

--- a/tests/Unit/AutoloadingTest.php
+++ b/tests/Unit/AutoloadingTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+use HenkPoley\DocBlockDoctor\AstUtils;
+use HenkPoley\DocBlockDoctor\ThrowsGatherer;
+use HenkPoley\DocBlockDoctor\GlobalCache;
+use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
+use PhpParser\NodeFinder;
+use PHPUnit\Framework\TestCase;
+
+class AutoloadingTest extends TestCase
+{
+    private AstUtils $utils;
+    private NodeFinder $finder;
+
+    protected function setUp(): void
+    {
+        $this->utils = new AstUtils();
+        $this->finder = new NodeFinder();
+        GlobalCache::clear();
+    }
+
+    public function testThrowsGathererDoesNotAutoloadMissingClasses(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        function foo() {
+            throw new \Nonexistent\CustomException();
+        }
+        PHP;
+
+        $autoloadCalled = false;
+        $loader = function ($class) use (&$autoloadCalled) {
+            $autoloadCalled = true;
+            throw new RuntimeException('Autoload attempted for ' . $class);
+        };
+        spl_autoload_register($loader);
+        try {
+            $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+            $ast = $parser->parse($code) ?: [];
+            $traverser = new NodeTraverser();
+            $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+            $traverser->addVisitor(new ParentConnectingVisitor());
+            $tg = new ThrowsGatherer($this->finder, $this->utils, 'dummy');
+            $traverser->addVisitor($tg);
+            try {
+                $traverser->traverse($ast);
+            } catch (RuntimeException $e) {
+                $this->fail('Autoloader was triggered: ' . $e->getMessage());
+            }
+        } finally {
+            spl_autoload_unregister($loader);
+        }
+
+        $this->assertFalse($autoloadCalled, 'Autoloader should not be called');
+        // Non-existent classes should be filtered out
+        $this->assertSame([], GlobalCache::$directThrows['foo'] ?? []);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid triggering autoload for class lookups
- check composer class maps without loading files
- keep nonexistent exceptions filtered
- add regression test

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6841d7d2a27c832895d79fb75da32f57