### PR TITLE
Handle single-line function docblocks

### DIFF
--- a/src/DocBlockUpdater.php
+++ b/src/DocBlockUpdater.php
@@ -125,8 +125,16 @@ class DocBlockUpdater extends NodeVisitorAbstract
             $currentGenericTagLines = [];
             $isInsideGenericTag = false;
 
-            for ($lineIdx = 1; $lineIdx < count($originalLines) - 1; $lineIdx++) {
+            for ($lineIdx = 0; $lineIdx < count($originalLines); $lineIdx++) {
                 $currentDocLine = $originalLines[$lineIdx];
+                $isFirst = ($lineIdx === 0 && preg_match('/^\s*\/\*\*/', $currentDocLine));
+                $isLast  = ($lineIdx === count($originalLines) - 1 && preg_match('/\*\/\s*$/', $currentDocLine));
+                if ($isFirst) {
+                    $currentDocLine = preg_replace('/^\s*\/\*\*\s?/', '', $currentDocLine);
+                }
+                if ($isLast) {
+                    $currentDocLine = preg_replace('/\s*\*\/$/', '', $currentDocLine);
+                }
                 $lineContent = preg_replace('/^\s*\*?\s?/', '', $currentDocLine);
                 $trimmedLineContent = trim((string)$lineContent);
 
@@ -219,9 +227,18 @@ class DocBlockUpdater extends NodeVisitorAbstract
             $originalDocText = $docCommentNode->getText();
             $originalContentOnlyLines = [];
             $lines = preg_split('/\R/u', $originalDocText) ?: [];
-            if (count($lines) > 1) {
-                for ($i = 1; $i < count($lines) - 1; $i++) {
-                    $originalContentOnlyLines[] = preg_replace('/^\s*\*?\s?/', '', $lines[$i]);
+            if ($lines !== []) {
+                foreach ($lines as $i => $line) {
+                    $isFirst = ($i === 0 && preg_match('/^\s*\/\*\*/', $line));
+                    $isLast  = ($i === count($lines) - 1 && preg_match('/\*\/\s*$/', $line));
+                    if ($isFirst) {
+                        $line = preg_replace('/^\s*\/\*\*\s?/', '', $line);
+                    }
+                    if ($isLast) {
+                        $line = preg_replace('/\s*\*\/$/', '', $line);
+                    }
+                    $line = preg_replace('/^\s*\*?\s?/', '', $line);
+                    $originalContentOnlyLines[] = $line;
                 }
                 $originalTextToNormalize = implode("\n", $originalContentOnlyLines);
                 $originalNormalizedDocText = $this->normalizeDocBlockString($originalTextToNormalize);

--- a/tests/NewIntegration/DocBlockUpdaterIntegrationTest.php
+++ b/tests/NewIntegration/DocBlockUpdaterIntegrationTest.php
@@ -21,11 +21,11 @@ use HenkPoley\DocBlockDoctor\DocBlockUpdater;
  */
 class DocBlockUpdaterIntegrationTest extends TestCase
 {
-    public function testRewrittenDocblocksMatchExpected(): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('fixtureProvider')]
+    public function testRewrittenDocblocksMatchExpected(string $scenario, string $fileName): void
     {
-        // Use the constructor-throws fixture to validate docblock rewriting
-        $fixtureDir = __DIR__ . '/../fixtures/constructor-throws';
-        $inputFile  = $fixtureDir . '/ThrowsInConstructor.php';
+        $fixtureDir = __DIR__ . '/../fixtures/' . $scenario;
+        $inputFile  = $fixtureDir . '/' . $fileName;
         $expectedOut = $fixtureDir . '/expected_rewritten.php';
 
         // 1) Read input
@@ -158,5 +158,13 @@ class DocBlockUpdaterIntegrationTest extends TestCase
         $expectedCode = file_get_contents($expectedOut);
         $this->assertNotFalse($expectedCode);
         $this->assertSame($expectedCode, $patchedCode, 'Rewritten code did not match expected for docblock rewrite');
+    }
+
+    public static function fixtureProvider(): array
+    {
+        return [
+            ['constructor-throws', 'ThrowsInConstructor.php'],
+            ['single-line-method-docblock', 'InlineDocblock.php'],
+        ];
     }
 }

--- a/tests/fixtures/single-line-method-docblock/InlineDocblock.php
+++ b/tests/fixtures/single-line-method-docblock/InlineDocblock.php
@@ -1,0 +1,20 @@
+<?php
+// tests/fixtures/single-line-method-docblock/InlineDocblock.php
+
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\TestFixtures\SingleLineMethodDocblock;
+
+class InlineDocblock
+{
+    /** @param int[] $vals */
+    public function compute(array $vals): void
+    {
+        throw new \LogicException();
+    }
+
+    public function run(): void
+    {
+        $this->compute([1]);
+    }
+}

--- a/tests/fixtures/single-line-method-docblock/expected_results.json
+++ b/tests/fixtures/single-line-method-docblock/expected_results.json
@@ -1,0 +1,10 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\SingleLineMethodDocblock\\InlineDocblock::compute": [
+      "LogicException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\SingleLineMethodDocblock\\InlineDocblock::run": [
+      "LogicException"
+    ]
+  }
+}

--- a/tests/fixtures/single-line-method-docblock/expected_rewritten.php
+++ b/tests/fixtures/single-line-method-docblock/expected_rewritten.php
@@ -1,0 +1,27 @@
+<?php
+// tests/fixtures/single-line-method-docblock/InlineDocblock.php
+
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\TestFixtures\SingleLineMethodDocblock;
+
+class InlineDocblock
+{
+    /**
+     * @param int[] $vals
+     *
+     * @throws \LogicException
+     */
+    public function compute(array $vals): void
+    {
+        throw new \LogicException();
+    }
+
+    /**
+     * @throws \LogicException
+     */
+    public function run(): void
+    {
+        $this->compute([1]);
+    }
+}


### PR DESCRIPTION
## Summary
- handle single line docblocks when rewriting
- cover new case with fixtures and tests

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6841e06713248328bf7af22662e4a9e8