### PR TITLE
Fix throw new variable class string handling

### DIFF
--- a/tests/Unit/ThrowsGathererTest.php
+++ b/tests/Unit/ThrowsGathererTest.php
@@ -208,4 +208,34 @@ class ThrowsGathererTest extends TestCase
         $this->assertArrayHasKey($key, GlobalCache::$directThrows);
         $this->assertSame([], GlobalCache::$directThrows[$key]);
     }
+
+    /**
+     * @throws \LogicException
+     */
+    public function testCalculateDirectThrowsFromClassStringVariable(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace T;
+        class C {
+            public function foo(): void {
+                $exc = \RuntimeException::class;
+                throw new $exc('fail');
+            }
+        }
+        PHP;
+
+        $parser   = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast      = $parser->parse($code) ?: [];
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $tg = new ThrowsGatherer($this->finder, $this->utils, 'dummyPath');
+        $traverser->addVisitor($tg);
+        $traverser->traverse($ast);
+
+        $key = 'T\\C::foo';
+        $this->assertArrayHasKey($key, GlobalCache::$directThrows);
+        $this->assertEquals(['RuntimeException'], GlobalCache::$directThrows[$key]);
+    }
 }

--- a/tests/fixtures/throw-class-string/expected_results.json
+++ b/tests/fixtures/throw-class-string/expected_results.json
@@ -6,7 +6,6 @@
     "Pitfalls\\ThrowClassString\\ThingThatCalls::second": [
       "BadMethodCallException"
     ],
-    ,
     "Pitfalls\\ThrowClassString\\ThingThatCalls::third": [
       "DivisionByZeroError"
     ]


### PR DESCRIPTION
## Summary
- fix invalid fixture json
- support `throw new $foo()` when `$foo` is a class-string
- add a test for class-string throws

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/psalm --no-progress` *(fails: 27 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684264da022c8328ad6e02f1aa6cbac1