### PR TITLE
Prevent autoloading vendor classes during analysis

### DIFF
--- a/tests/unit_fixtures/vendor-catch/vendor/Vend/ChildException.php
+++ b/tests/unit_fixtures/vendor-catch/vendor/Vend/ChildException.php
@@ -1,0 +1,3 @@
+<?php
+namespace Vend;
+class ChildException extends ParentException {}

--- a/tests/unit_fixtures/vendor-catch/vendor/Vend/ParentException.php
+++ b/tests/unit_fixtures/vendor-catch/vendor/Vend/ParentException.php
@@ -1,0 +1,3 @@
+<?php
+namespace Vend;
+class ParentException extends \Exception {}


### PR DESCRIPTION
## Summary
- avoid autoloading vendor classes when checking caught exceptions
- expose helper to detect vendor class files
- add vendor-style fixture
- test that vendor autoloaders are not triggered

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684266b9df9c832884c2c2b5442edbe9