### PR TITLE
Add throw origin tracing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ php ./vendor/bin/doc-block-doctor [options] <path>
 Options:
   --read-dirs=DIRS   Comma-separated list of directories to read when gathering info (default: src,tests)
   --write-dirs=DIRS  Comma-separated list of directories that may be modified (default: src)
-  --trace-throw-origins  Replace @throws descriptions with origin locations
+  --trace-throw-origins  Replace @throws descriptions with origin locations and call chain
 ```
 
 ## Result

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ php ./vendor/bin/doc-block-doctor [options] <path>
 Options:
   --read-dirs=DIRS   Comma-separated list of directories to read when gathering info (default: src,tests)
   --write-dirs=DIRS  Comma-separated list of directories that may be modified (default: src)
+  --trace-throw-origins  Replace @throws descriptions with origin locations
 ```
 
 ## Result

--- a/src/Application.php
+++ b/src/Application.php
@@ -307,7 +307,7 @@ class Application
                                         continue;
                                     }
                                     $callSite = $filePathOfFunc . ':' . $callNode->getStartLine();
-                                    $newChain = $callSite . ' <- ' . $chainWithoutSite;
+                                    $newChain = $callSite . ' <- ' . $funcKey . ' <- ' . $chainWithoutSite;
                                     if (!in_array($newChain, $originsFromCallees[$ex], true) && count($originsFromCallees[$ex]) < GlobalCache::MAX_ORIGIN_CHAINS) {
                                         $originsFromCallees[$ex][] = $newChain;
                                     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -298,12 +298,16 @@ class Application
                                     if (strpos($chain, $funcKey . ' <- ') !== false) {
                                         continue; // avoid infinite recursion
                                     }
-                                    $pos = strrpos($chain, ' <- ');
-                                    if ($pos === false) {
-                                        $newChain = $funcKey . ' <- ' . $chain;
-                                    } else {
-                                        $newChain = substr($chain, 0, $pos) . ' <- ' . $funcKey . substr($chain, $pos);
+                                    $segments = explode(' <- ', $chain);
+                                    if ($segments !== [] && preg_match('/:\d+$/', $segments[0])) {
+                                        array_shift($segments);
                                     }
+                                    $chainWithoutSite = implode(' <- ', $segments);
+                                    if ($chainWithoutSite === '') {
+                                        continue;
+                                    }
+                                    $callSite = $filePathOfFunc . ':' . $callNode->getStartLine();
+                                    $newChain = $callSite . ' <- ' . $chainWithoutSite;
                                     if (!in_array($newChain, $originsFromCallees[$ex], true) && count($originsFromCallees[$ex]) < GlobalCache::MAX_ORIGIN_CHAINS) {
                                         $originsFromCallees[$ex][] = $newChain;
                                     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -294,7 +294,12 @@ class Application
                                 if (!isset($originsFromCallees[$ex])) {
                                     $originsFromCallees[$ex] = [];
                                 }
-                                $originsFromCallees[$ex] = array_merge($originsFromCallees[$ex], $orig);
+                                foreach ($orig as $chain) {
+                                    $newChain = $chain;
+                                    $insertPos = count($newChain) - 1;
+                                    array_splice($newChain, $insertPos, 0, [$funcKey]);
+                                    $originsFromCallees[$ex][] = $newChain;
+                                }
                             }
                         }
                     }
@@ -311,7 +316,7 @@ class Application
                     $newOrigins[$ex] = array_merge($newOrigins[$ex], $list);
                 }
                 foreach ($newOrigins as $ex => $list) {
-                    $newOrigins[$ex] = array_values(array_unique($list));
+                    $newOrigins[$ex] = array_values(array_map('unserialize', array_unique(array_map('serialize', $list))));
                 }
 
                 $oldThrows = GlobalCache::$resolvedThrows[$funcKey] ?? [];
@@ -598,7 +603,7 @@ Options:
   -v, --verbose    Enable verbose output (show each file being processed)
   --read-dirs=DIRS   Comma-separated list of directories to read
   --write-dirs=DIRS  Comma-separated list of directories to update
-  --trace-throw-origins  Replace @throws descriptions with origin locations
+  --trace-throw-origins  Replace @throws descriptions with origin locations and call chain
 
 Arguments:
   <path>           Path to a file or directory to process.

--- a/src/Application.php
+++ b/src/Application.php
@@ -295,9 +295,12 @@ class Application
                                     $originsFromCallees[$ex] = [];
                                 }
                                 foreach ($orig as $chain) {
-                                    $newChain = $chain;
-                                    $insertPos = count($newChain) - 1;
-                                    array_splice($newChain, $insertPos, 0, [$funcKey]);
+                                    $pos = strrpos($chain, ' <- ');
+                                    if ($pos === false) {
+                                        $newChain = $funcKey . ' <- ' . $chain;
+                                    } else {
+                                        $newChain = substr($chain, 0, $pos) . ' <- ' . $funcKey . substr($chain, $pos);
+                                    }
                                     $originsFromCallees[$ex][] = $newChain;
                                 }
                             }
@@ -316,7 +319,7 @@ class Application
                     $newOrigins[$ex] = array_merge($newOrigins[$ex], $list);
                 }
                 foreach ($newOrigins as $ex => $list) {
-                    $newOrigins[$ex] = array_values(array_map('unserialize', array_unique(array_map('serialize', $list))));
+                    $newOrigins[$ex] = array_values(array_unique($list));
                 }
 
                 $oldThrows = GlobalCache::$resolvedThrows[$funcKey] ?? [];

--- a/src/DocBlockUpdater.php
+++ b/src/DocBlockUpdater.php
@@ -196,7 +196,14 @@ class DocBlockUpdater extends NodeVisitorAbstract
                 $fqcnWithBackslash = '\\' . ltrim((string)$fqcn, '\\');
                 if ($this->traceOrigins) {
                     $originChains = \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$nodeKey][$fqcn] ?? [];
-                    $description = implode(', ', $originChains);
+                    $cleaned = [];
+                    foreach ($originChains as $ch) {
+                        if (strpos($ch, $nodeKey . ' <- ') === 0) {
+                            $ch = substr($ch, strlen($nodeKey . ' <- '));
+                        }
+                        $cleaned[] = $ch;
+                    }
+                    $description = implode(', ', $cleaned);
                 } else {
                     $description = $originalNodeDescriptions[$fqcn] ?? ($originalNodeDescriptions[ltrim((string)$fqcn, '\\')] ?? '');
                 }

--- a/src/DocBlockUpdater.php
+++ b/src/DocBlockUpdater.php
@@ -10,6 +10,7 @@ class DocBlockUpdater extends NodeVisitorAbstract
 {
     private \HenkPoley\DocBlockDoctor\AstUtils $astUtils;
     private string $currentFilePath;
+    private bool $traceOrigins;
     /**
      * @var mixed[]
      */
@@ -19,10 +20,11 @@ class DocBlockUpdater extends NodeVisitorAbstract
      */
     private $currentNamespace = '';
 
-    public function __construct(\HenkPoley\DocBlockDoctor\AstUtils $astUtils, string $currentFilePath)
+    public function __construct(\HenkPoley\DocBlockDoctor\AstUtils $astUtils, string $currentFilePath, bool $traceOrigins = false)
     {
         $this->astUtils = $astUtils;
         $this->currentFilePath = $currentFilePath;
+        $this->traceOrigins = $traceOrigins;
     }
 
     /**
@@ -192,7 +194,12 @@ class DocBlockUpdater extends NodeVisitorAbstract
                 // This foreach() is not dead code.
                 // tombstone("ERROR: NoValue - src/DocBlockUpdater.php:188:46 - All possible types for this assignment were invalidated - This may be dead code (see https://psalm.dev/179)");
                 $fqcnWithBackslash = '\\' . ltrim((string)$fqcn, '\\');
-                $description = $originalNodeDescriptions[$fqcn] ?? ($originalNodeDescriptions[ltrim((string)$fqcn, '\\')] ?? '');
+                if ($this->traceOrigins) {
+                    $origins = \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$nodeKey][$fqcn] ?? [];
+                    $description = implode(', ', $origins);
+                } else {
+                    $description = $originalNodeDescriptions[$fqcn] ?? ($originalNodeDescriptions[ltrim((string)$fqcn, '\\')] ?? '');
+                }
                 $throwsLine = '@throws ' . $fqcnWithBackslash;
                 if (!empty($description)) {
                     $descLines = explode("\n", (string)$description);

--- a/src/DocBlockUpdater.php
+++ b/src/DocBlockUpdater.php
@@ -195,8 +195,11 @@ class DocBlockUpdater extends NodeVisitorAbstract
                 // tombstone("ERROR: NoValue - src/DocBlockUpdater.php:188:46 - All possible types for this assignment were invalidated - This may be dead code (see https://psalm.dev/179)");
                 $fqcnWithBackslash = '\\' . ltrim((string)$fqcn, '\\');
                 if ($this->traceOrigins) {
-                    $origins = \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$nodeKey][$fqcn] ?? [];
-                    $description = implode(', ', $origins);
+                    $originChains = \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$nodeKey][$fqcn] ?? [];
+                    $originStrings = array_map(static function (array $chain): string {
+                        return implode(' <- ', $chain);
+                    }, $originChains);
+                    $description = implode(', ', $originStrings);
                 } else {
                     $description = $originalNodeDescriptions[$fqcn] ?? ($originalNodeDescriptions[ltrim((string)$fqcn, '\\')] ?? '');
                 }

--- a/src/DocBlockUpdater.php
+++ b/src/DocBlockUpdater.php
@@ -200,6 +200,8 @@ class DocBlockUpdater extends NodeVisitorAbstract
                     foreach ($originChains as $ch) {
                         if (strpos($ch, $nodeKey . ' <- ') === 0) {
                             $ch = substr($ch, strlen($nodeKey . ' <- '));
+                        } elseif (preg_match('/^(.*?:\d+) <- ' . preg_quote($nodeKey, '/') . ' <- (.*)$/', $ch, $m)) {
+                            $ch = $m[1] . ' <- ' . $m[2];
                         }
                         $cleaned[] = $ch;
                     }

--- a/src/DocBlockUpdater.php
+++ b/src/DocBlockUpdater.php
@@ -196,10 +196,7 @@ class DocBlockUpdater extends NodeVisitorAbstract
                 $fqcnWithBackslash = '\\' . ltrim((string)$fqcn, '\\');
                 if ($this->traceOrigins) {
                     $originChains = \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$nodeKey][$fqcn] ?? [];
-                    $originStrings = array_map(static function (array $chain): string {
-                        return implode(' <- ', $chain);
-                    }, $originChains);
-                    $description = implode(', ', $originStrings);
+                    $description = implode(', ', $originChains);
                 } else {
                     $description = $originalNodeDescriptions[$fqcn] ?? ($originalNodeDescriptions[ltrim((string)$fqcn, '\\')] ?? '');
                 }

--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -37,9 +37,9 @@ class GlobalCache
      */
     public static $resolvedThrows = [];
     /**
-     * @var array<string,array<string,list<list<string>>>> Mapping of method key to
-     * exception FQCN to a list of origin call chains. Each call chain is a list
-     * like ["Inner::method", "Outer::method", "file.php:line"].
+     * @var array<string,array<string,string[]>> Mapping of method key to
+     * exception FQCN to a list of origin call chain strings. Each chain looks
+     * like "Inner::method <- Outer::method <- file.php:line".
      */
     public static $throwOrigins = [];
 

--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -40,8 +40,12 @@ class GlobalCache
     public static $resolvedThrows = [];
     /**
      * @var array<string,array<string,string[]>> Mapping of method key to
-     * exception FQCN to a list of origin call chain strings. Each chain looks
-     * like "Inner::method <- Outer::method <- file.php:line".
+     * exception FQCN to a list of origin call chain strings. For each method,
+     * each chain starts with the call site location within that method,
+     * followed by the sequence of callee method names in order of invocation
+     * and ends with the file and line where the exception was originally
+     * thrown. Example:
+     * "src/File.php:10 <- SomeClass::method <- Other::callee <- vendor/lib.php:5".
      */
     public static $throwOrigins = [];
 

--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -36,6 +36,11 @@ class GlobalCache
      * @var mixed[]
      */
     public static $resolvedThrows = [];
+    /**
+     * @var array<string,array<string,list<string>>> Mapping of method key to
+     * exception FQCN to a list of origin locations (file:line)
+     */
+    public static $throwOrigins = [];
 
     public static function clear(): void
     {
@@ -47,5 +52,6 @@ class GlobalCache
         self::$astNodeMap = [];
         self::$nodeKeyToFilePath = [];
         self::$resolvedThrows = [];
+        self::$throwOrigins = [];
     }
 }

--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -4,6 +4,8 @@ namespace HenkPoley\DocBlockDoctor;
 
 class GlobalCache
 {
+    /** Max number of origin call chains stored per exception */
+    public const MAX_ORIGIN_CHAINS = 5;
     /**
      * @var mixed[]
      */

--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -37,8 +37,9 @@ class GlobalCache
      */
     public static $resolvedThrows = [];
     /**
-     * @var array<string,array<string,list<string>>> Mapping of method key to
-     * exception FQCN to a list of origin locations (file:line)
+     * @var array<string,array<string,list<list<string>>>> Mapping of method key to
+     * exception FQCN to a list of origin call chains. Each call chain is a list
+     * like ["Inner::method", "Outer::method", "file.php:line"].
      */
     public static $throwOrigins = [];
 

--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -208,7 +208,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
                     )) {
                         $fqcns[] = $thrownFqcn;
                         $loc = $this->filePath . ':' . $throwExpr->getStartLine();
-                        \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn][] = $loc;
+                        \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn][] = [$funcKey, $loc];
                     }
                 } elseif ($newExpr->class instanceof Node\Expr\Variable) {
                     $varName = $newExpr->class->name;
@@ -227,7 +227,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
                         )) {
                             $fqcns[] = $classFqcn;
                             $loc = $this->filePath . ':' . $throwExpr->getStartLine();
-                            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$classFqcn][] = $loc;
+                            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$classFqcn][] = [$funcKey, $loc];
                         }
                     }
                 }
@@ -253,7 +253,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
                                 if (!$this->astUtils->isExceptionCaught($throwExpr, $thrownFqcn, $funcOrMethodNode, $this->currentNamespace, $this->useMap)) {
                                     $fqcns[] = $thrownFqcn;
                                     $loc = $this->filePath . ':' . $throwExpr->getStartLine();
-                                    \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn][] = $loc;
+                                    \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn][] = [$funcKey, $loc];
                                 }
                             }
                         }
@@ -262,7 +262,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
                             if (!$this->astUtils->isExceptionCaught($throwExpr, $fq, $funcOrMethodNode, $this->currentNamespace, $this->useMap)) {
                                 $fqcns[] = $fq;
                                 $loc = $this->filePath . ':' . $throwExpr->getStartLine();
-                                \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq][] = $loc;
+                                \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq][] = [$funcKey, $loc];
                             }
                         }
                     } else {
@@ -271,7 +271,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
                             if (!$this->astUtils->isExceptionCaught($throwExpr, $fq, $funcOrMethodNode, $this->currentNamespace, $this->useMap)) {
                                 $fqcns[] = $fq;
                                 $loc = $this->filePath . ':' . $throwExpr->getStartLine();
-                                \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq][] = $loc;
+                                \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq][] = [$funcKey, $loc];
                             }
                         }
                     }
@@ -284,7 +284,8 @@ class ThrowsGatherer extends NodeVisitorAbstract
         );
 
         foreach (\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey] as $ex => $origins) {
-            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$ex] = array_values(array_unique($origins));
+            $unique = array_values(array_map('unserialize', array_unique(array_map('serialize', $origins))));
+            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$ex] = $unique;
         }
 
         return array_values(array_unique($filtered));

--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -208,7 +208,8 @@ class ThrowsGatherer extends NodeVisitorAbstract
                     )) {
                         $fqcns[] = $thrownFqcn;
                         $loc = $this->filePath . ':' . $throwExpr->getStartLine();
-                        \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn][] = [$funcKey, $loc];
+                        $chain = $funcKey . ' <- ' . $loc;
+                        \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn][] = $chain;
                     }
                 } elseif ($newExpr->class instanceof Node\Expr\Variable) {
                     $varName = $newExpr->class->name;
@@ -227,7 +228,8 @@ class ThrowsGatherer extends NodeVisitorAbstract
                         )) {
                             $fqcns[] = $classFqcn;
                             $loc = $this->filePath . ':' . $throwExpr->getStartLine();
-                            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$classFqcn][] = [$funcKey, $loc];
+                            $chain = $funcKey . ' <- ' . $loc;
+                            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$classFqcn][] = $chain;
                         }
                     }
                 }
@@ -253,7 +255,8 @@ class ThrowsGatherer extends NodeVisitorAbstract
                                 if (!$this->astUtils->isExceptionCaught($throwExpr, $thrownFqcn, $funcOrMethodNode, $this->currentNamespace, $this->useMap)) {
                                     $fqcns[] = $thrownFqcn;
                                     $loc = $this->filePath . ':' . $throwExpr->getStartLine();
-                                    \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn][] = [$funcKey, $loc];
+                                    $chain = $funcKey . ' <- ' . $loc;
+                                    \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn][] = $chain;
                                 }
                             }
                         }
@@ -262,7 +265,8 @@ class ThrowsGatherer extends NodeVisitorAbstract
                             if (!$this->astUtils->isExceptionCaught($throwExpr, $fq, $funcOrMethodNode, $this->currentNamespace, $this->useMap)) {
                                 $fqcns[] = $fq;
                                 $loc = $this->filePath . ':' . $throwExpr->getStartLine();
-                                \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq][] = [$funcKey, $loc];
+                                $chain = $funcKey . ' <- ' . $loc;
+                                \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq][] = $chain;
                             }
                         }
                     } else {
@@ -271,7 +275,8 @@ class ThrowsGatherer extends NodeVisitorAbstract
                             if (!$this->astUtils->isExceptionCaught($throwExpr, $fq, $funcOrMethodNode, $this->currentNamespace, $this->useMap)) {
                                 $fqcns[] = $fq;
                                 $loc = $this->filePath . ':' . $throwExpr->getStartLine();
-                                \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq][] = [$funcKey, $loc];
+                                $chain = $funcKey . ' <- ' . $loc;
+                                \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq][] = $chain;
                             }
                         }
                     }
@@ -284,8 +289,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
         );
 
         foreach (\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey] as $ex => $origins) {
-            $unique = array_values(array_map('unserialize', array_unique(array_map('serialize', $origins))));
-            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$ex] = $unique;
+            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$ex] = array_values(array_unique($origins));
         }
 
         return array_values(array_unique($filtered));

--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -209,7 +209,13 @@ class ThrowsGatherer extends NodeVisitorAbstract
                         $fqcns[] = $thrownFqcn;
                         $loc = $this->filePath . ':' . $throwExpr->getStartLine();
                         $chain = $funcKey . ' <- ' . $loc;
-                        \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn][] = $chain;
+                        if (!isset(\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn])) {
+                            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn] = [];
+                        }
+                        $origins = &\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn];
+                        if (!in_array($chain, $origins, true) && count($origins) < \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS) {
+                            $origins[] = $chain;
+                        }
                     }
                 } elseif ($newExpr->class instanceof Node\Expr\Variable) {
                     $varName = $newExpr->class->name;
@@ -229,7 +235,13 @@ class ThrowsGatherer extends NodeVisitorAbstract
                             $fqcns[] = $classFqcn;
                             $loc = $this->filePath . ':' . $throwExpr->getStartLine();
                             $chain = $funcKey . ' <- ' . $loc;
-                            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$classFqcn][] = $chain;
+                            if (!isset(\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$classFqcn])) {
+                                \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$classFqcn] = [];
+                            }
+                            $origins = &\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$classFqcn];
+                            if (!in_array($chain, $origins, true) && count($origins) < \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS) {
+                                $origins[] = $chain;
+                            }
                         }
                     }
                 }
@@ -256,7 +268,13 @@ class ThrowsGatherer extends NodeVisitorAbstract
                                     $fqcns[] = $thrownFqcn;
                                     $loc = $this->filePath . ':' . $throwExpr->getStartLine();
                                     $chain = $funcKey . ' <- ' . $loc;
-                                    \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn][] = $chain;
+                                    if (!isset(\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn])) {
+                                        \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn] = [];
+                                    }
+                                    $origins = &\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn];
+                                    if (!in_array($chain, $origins, true) && count($origins) < \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS) {
+                                        $origins[] = $chain;
+                                    }
                                 }
                             }
                         }
@@ -266,7 +284,13 @@ class ThrowsGatherer extends NodeVisitorAbstract
                                 $fqcns[] = $fq;
                                 $loc = $this->filePath . ':' . $throwExpr->getStartLine();
                                 $chain = $funcKey . ' <- ' . $loc;
-                                \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq][] = $chain;
+                                if (!isset(\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq])) {
+                                    \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq] = [];
+                                }
+                                $origins = &\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq];
+                                if (!in_array($chain, $origins, true) && count($origins) < \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS) {
+                                    $origins[] = $chain;
+                                }
                             }
                         }
                     } else {
@@ -276,7 +300,13 @@ class ThrowsGatherer extends NodeVisitorAbstract
                                 $fqcns[] = $fq;
                                 $loc = $this->filePath . ':' . $throwExpr->getStartLine();
                                 $chain = $funcKey . ' <- ' . $loc;
-                                \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq][] = $chain;
+                                if (!isset(\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq])) {
+                                    \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq] = [];
+                                }
+                                $origins = &\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq];
+                                if (!in_array($chain, $origins, true) && count($origins) < \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS) {
+                                    $origins[] = $chain;
+                                }
                             }
                         }
                     }
@@ -289,7 +319,11 @@ class ThrowsGatherer extends NodeVisitorAbstract
         );
 
         foreach (\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey] as $ex => $origins) {
-            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$ex] = array_values(array_unique($origins));
+            $origins = array_values(array_unique($origins));
+            if (count($origins) > \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS) {
+                $origins = array_slice($origins, 0, \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS);
+            }
+            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$ex] = $origins;
         }
 
         return array_values(array_unique($filtered));

--- a/tests/Unit/TraceOriginsTest.php
+++ b/tests/Unit/TraceOriginsTest.php
@@ -51,7 +51,7 @@ class TraceOriginsTest extends TestCase
 
         $this->assertNotEmpty($updater->pendingPatches);
         $patch = $updater->pendingPatches[0];
-        $this->assertStringContainsString('@throws \\RuntimeException dummy.php:3', $patch['newDocText']);
+        $this->assertStringContainsString('@throws \\RuntimeException foo <- dummy.php:3', $patch['newDocText']);
     }
 }
 

--- a/tests/Unit/TraceOriginsTest.php
+++ b/tests/Unit/TraceOriginsTest.php
@@ -51,7 +51,7 @@ class TraceOriginsTest extends TestCase
 
         $this->assertNotEmpty($updater->pendingPatches);
         $patch = $updater->pendingPatches[0];
-        $this->assertStringContainsString('@throws \\RuntimeException foo <- dummy.php:3', $patch['newDocText']);
+        $this->assertStringContainsString('@throws \\RuntimeException dummy.php:3', $patch['newDocText']);
     }
 }
 

--- a/tests/Unit/TraceOriginsTest.php
+++ b/tests/Unit/TraceOriginsTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+use PhpParser\ParserFactory;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
+use PhpParser\NodeFinder;
+use PhpParser\PhpVersion;
+use PHPUnit\Framework\TestCase;
+use HenkPoley\DocBlockDoctor\AstUtils;
+use HenkPoley\DocBlockDoctor\ThrowsGatherer;
+use HenkPoley\DocBlockDoctor\GlobalCache;
+use HenkPoley\DocBlockDoctor\DocBlockUpdater;
+
+class TraceOriginsTest extends TestCase
+{
+    /**
+     * @throws \LogicException
+     */
+    public function testTraceOriginsAddsLocationToDocblock(): void
+    {
+        $code = "<?php\nfunction foo() {\n    throw new \RuntimeException();\n}\n";
+        GlobalCache::clear();
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast    = $parser->parse($code) ?: [];
+
+        $tr1 = new NodeTraverser();
+        $tr1->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $tr1->addVisitor(new ParentConnectingVisitor());
+        $finder = new NodeFinder();
+        $utils  = new AstUtils();
+        $tg     = new ThrowsGatherer($finder, $utils, 'dummy.php');
+        $tr1->addVisitor($tg);
+        $tr1->traverse($ast);
+
+        foreach (array_keys(GlobalCache::$astNodeMap) as $key) {
+            $direct    = GlobalCache::$directThrows[$key] ?? [];
+            $annotated = GlobalCache::$annotatedThrows[$key] ?? [];
+            $combined  = array_values(array_unique(array_merge($direct, $annotated)));
+            sort($combined);
+            GlobalCache::$resolvedThrows[$key] = $combined;
+        }
+
+        $tr2 = new NodeTraverser();
+        $tr2->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $tr2->addVisitor(new ParentConnectingVisitor());
+        $updater = new DocBlockUpdater($utils, 'dummy.php', true);
+        $tr2->addVisitor($updater);
+        $tr2->traverse($ast);
+
+        $this->assertNotEmpty($updater->pendingPatches);
+        $patch = $updater->pendingPatches[0];
+        $this->assertStringContainsString('@throws \\RuntimeException dummy.php:3', $patch['newDocText']);
+    }
+}
+


### PR DESCRIPTION
## Summary
- track origins of thrown exceptions
- allow `--trace-throw-origins` option
- update docblocks to use origins when enabled
- document new option in README
- test tracing feature

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6842744337308328ae7666b4144c7222