### PR TITLE
Add trace-throw-call-sites option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Options:
   --read-dirs=DIRS   Comma-separated list of directories to read when gathering info (default: src,tests)
   --write-dirs=DIRS  Comma-separated list of directories that may be modified (default: src)
   --trace-throw-origins  Replace @throws descriptions with origin locations and call chain
+  --trace-throw-call-sites  Replace @throws descriptions with call site line numbers
 ```
 
 ## Result

--- a/src/Application.php
+++ b/src/Application.php
@@ -40,6 +40,7 @@ class Application
         // ------------------------------------------------------------
         $verbose       = false;
         $traceOrigins  = false;
+        $traceCallSites = false;
         $rootDir       = null;
         $readDirs      = null;
         $writeDirs     = null;
@@ -55,6 +56,11 @@ class Application
 
             if ($arg === '--trace-throw-origins') {
                 $traceOrigins = true;
+                continue;
+            }
+
+            if ($arg === '--trace-throw-call-sites') {
+                $traceCallSites = true;
                 continue;
             }
 
@@ -455,7 +461,7 @@ class Application
                 }
                 // --- End Use Statement Simplification ---
 
-                $docBlockUpdater   = new DocBlockUpdater($astUtils, $filePath, $traceOrigins);
+                $docBlockUpdater   = new DocBlockUpdater($astUtils, $filePath, $traceOrigins, $traceCallSites);
                 $traverserDocBlock = new NodeTraverser();
                 $traverserDocBlock->addVisitor($docBlockUpdater);
                 $traverserDocBlock->traverse($currentAST);
@@ -624,6 +630,7 @@ Options:
   --read-dirs=DIRS   Comma-separated list of directories to read
   --write-dirs=DIRS  Comma-separated list of directories to update
   --trace-throw-origins  Replace @throws descriptions with origin locations and call chain
+  --trace-throw-call-sites  Replace @throws descriptions with call site line numbers
 
 Arguments:
   <path>           Path to a file or directory to process.

--- a/tests/NewIntegration/DocBlockUpdaterIntegrationTest.php
+++ b/tests/NewIntegration/DocBlockUpdaterIntegrationTest.php
@@ -104,7 +104,7 @@ class DocBlockUpdaterIntegrationTest extends TestCase
         $traverser2 = new NodeTraverser();
         $traverser2->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
         $traverser2->addVisitor(new ParentConnectingVisitor());
-        $docUpd      = new DocBlockUpdater($astUtils, $inputFile);
+        $docUpd      = new DocBlockUpdater($astUtils, $inputFile, false, false);
         $traverser2->addVisitor($docUpd);
         $traverser2->traverse($ast);
 

--- a/tests/Unit/TraceCallSitesTest.php
+++ b/tests/Unit/TraceCallSitesTest.php
@@ -13,12 +13,12 @@ use HenkPoley\DocBlockDoctor\ThrowsGatherer;
 use HenkPoley\DocBlockDoctor\GlobalCache;
 use HenkPoley\DocBlockDoctor\DocBlockUpdater;
 
-class TraceOriginsTest extends TestCase
+class TraceCallSitesTest extends TestCase
 {
     /**
      * @throws \LogicException
      */
-    public function testTraceOriginsAddsLocationToDocblock(): void
+    public function testTraceCallSitesAddsLineNumbers(): void
     {
         $code = "<?php\nfunction foo() {\n    throw new \RuntimeException();\n}\n";
         GlobalCache::clear();
@@ -45,13 +45,12 @@ class TraceOriginsTest extends TestCase
         $tr2 = new NodeTraverser();
         $tr2->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
         $tr2->addVisitor(new ParentConnectingVisitor());
-        $updater = new DocBlockUpdater($utils, 'dummy.php', true, false);
+        $updater = new DocBlockUpdater($utils, 'dummy.php', false, true);
         $tr2->addVisitor($updater);
         $tr2->traverse($ast);
 
         $this->assertNotEmpty($updater->pendingPatches);
         $patch = $updater->pendingPatches[0];
-        $this->assertStringContainsString('@throws \\RuntimeException dummy.php:3', $patch['newDocText']);
+        $this->assertStringContainsString('@throws \\RuntimeException :3', $patch['newDocText']);
     }
 }
-


### PR DESCRIPTION
## Summary
- add `--trace-throw-call-sites` option to show call site line numbers
- support new flag in `DocBlockUpdater` and CLI
- document the option in README and CLI help
- test tracing of call site numbers

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6843fe6e6bd88328a4fe26107d0ad2d6