### PR TITLE
Fix updating for empty docblocks

### DIFF
--- a/src/DocBlockUpdater.php
+++ b/src/DocBlockUpdater.php
@@ -294,11 +294,17 @@ class DocBlockUpdater extends NodeVisitorAbstract
                 $patchEnd = $docCommentNode->getEndFilePos();
             } elseif ($finalNormalizedNewDocText !== null) {
                 if ($originalNormalizedDocText === null) {
-                    $patchType = 'add';
-                    // For adding, $patchStart will be the start of the node itself (e.g., 'p' in 'public function')
-                    // The actual insertion point will be adjusted before this based on the node's line indent.
-                    $patchStart = $node->getStartFilePos();
-                    $patchEnd = $node->getStartFilePos() - 1; // No original length
+                    if ($docCommentNode instanceof \PhpParser\Comment\Doc) {
+                        $patchType = 'update';
+                        $patchStart = $docCommentNode->getStartFilePos();
+                        $patchEnd = $docCommentNode->getEndFilePos();
+                    } else {
+                        $patchType = 'add';
+                        // For adding, $patchStart will be the start of the node itself (e.g., 'p' in 'public function')
+                        // The actual insertion point will be adjusted before this based on the node's line indent.
+                        $patchStart = $node->getStartFilePos();
+                        $patchEnd = $node->getStartFilePos() - 1; // No original length
+                    }
                 } else {
                     $patchType = 'update';
                     if ($docCommentNode instanceof \PhpParser\Comment\Doc) {

--- a/tests/NewIntegration/DocBlockUpdaterIntegrationTest.php
+++ b/tests/NewIntegration/DocBlockUpdaterIntegrationTest.php
@@ -168,6 +168,7 @@ class DocBlockUpdaterIntegrationTest extends TestCase
         return [
             ['constructor-throws', 'ThrowsInConstructor.php'],
             ['single-line-method-docblock', 'InlineDocblock.php'],
+            ['empty-docblock', 'EmptyDocblock.php'],
         ];
     }
 }

--- a/tests/fixtures/empty-docblock/EmptyDocblock.php
+++ b/tests/fixtures/empty-docblock/EmptyDocblock.php
@@ -1,0 +1,16 @@
+<?php
+// tests/fixtures/empty-docblock/EmptyDocblock.php
+
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\TestFixtures\EmptyDocblock;
+
+class EmptyDocblock
+{
+    /**
+     */
+    public function emptyDocblock(): void
+    {
+        throw new \ParseError();
+    }
+}

--- a/tests/fixtures/empty-docblock/expected_results.json
+++ b/tests/fixtures/empty-docblock/expected_results.json
@@ -1,0 +1,7 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\EmptyDocblock\\EmptyDocblock::emptyDocblock": [
+      "ParseError"
+    ]
+  }
+}

--- a/tests/fixtures/empty-docblock/expected_rewritten.php
+++ b/tests/fixtures/empty-docblock/expected_rewritten.php
@@ -1,0 +1,17 @@
+<?php
+// tests/fixtures/empty-docblock/EmptyDocblock.php
+
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\TestFixtures\EmptyDocblock;
+
+class EmptyDocblock
+{
+    /**
+     * @throws \ParseError
+     */
+    public function emptyDocblock(): void
+    {
+        throw new \ParseError();
+    }
+}


### PR DESCRIPTION
## Summary
- fix DocBlockUpdater to replace an empty docblock instead of adding a second one
- add fixture covering empty docblock behaviour
- run integration/unit tests

## Testing
- `vendor/bin/phpunit --testsuite Unit`
- `vendor/bin/phpunit --testsuite Integration` *(fails: ThrowsResolutionIntegrationTest::catch-root-exception)*

------
https://chatgpt.com/codex/tasks/task_e_684405fe49288328befe462c7c244460