### PR TITLE
Resolve throws from inherited methods

### DIFF
--- a/src/AstUtils.php
+++ b/src/AstUtils.php
@@ -171,7 +171,15 @@ class AstUtils
                         );
                         if ($returnedFqcn !== '') {
                             $methodName = $callNode->name instanceof Node\Identifier ? $callNode->name->toString() : '';
-                            return ltrim($returnedFqcn, '\\') . '::' . $methodName;
+                            $decl = $this->findDeclaringClassForMethod(
+                                ltrim($returnedFqcn, '\\'),
+                                $methodName,
+                                $callerFuncOrMethodNode,
+                                $callerNamespace,
+                                $callerUseMap
+                            );
+                            $target = $decl ?? ltrim($returnedFqcn, '\\');
+                            return $target . '::' . $methodName;
                         }
                     } elseif ($returnType instanceof Node\NullableType && $returnType->type instanceof Node\Name) {
                         $returnedFqcn = $this->resolveNameNodeToFqcn(
@@ -182,7 +190,15 @@ class AstUtils
                         );
                         if ($returnedFqcn !== '') {
                             $methodName = $callNode->name instanceof Node\Identifier ? $callNode->name->toString() : '';
-                            return ltrim($returnedFqcn, '\\') . '::' . $methodName;
+                            $decl = $this->findDeclaringClassForMethod(
+                                ltrim($returnedFqcn, '\\'),
+                                $methodName,
+                                $callerFuncOrMethodNode,
+                                $callerNamespace,
+                                $callerUseMap
+                            );
+                            $target = $decl ?? ltrim($returnedFqcn, '\\');
+                            return $target . '::' . $methodName;
                         }
                     }
 
@@ -209,7 +225,15 @@ class AstUtils
                             if ($returnedFqcn !== '' && $returnedFqcn !== '0') {
                                 // 4) Synthesize “ReturnedClass::outerMethod”
                                 $methodName = $callNode->name instanceof Node\Identifier ? $callNode->name->toString() : '';
-                                return ltrim($returnedFqcn, '\\') . '::' . $methodName;
+                                $decl = $this->findDeclaringClassForMethod(
+                                    ltrim($returnedFqcn, '\\'),
+                                    $methodName,
+                                    $callerFuncOrMethodNode,
+                                    $callerNamespace,
+                                    $callerUseMap
+                                );
+                                $target = $decl ?? ltrim($returnedFqcn, '\\');
+                                return $target . '::' . $methodName;
                             }
                         }
                     }
@@ -264,7 +288,15 @@ class AstUtils
                                         $callerUseMap
                                     );
                                     if ($fqcn !== '') {
-                                        return ltrim($fqcn, '\\') . '::' . $methodName;
+                                        $decl = $this->findDeclaringClassForMethod(
+                                            ltrim($fqcn, '\\'),
+                                            $methodName,
+                                            $callerFuncOrMethodNode,
+                                            $callerNamespace,
+                                            $callerUseMap
+                                        );
+                                        $target = $decl ?? ltrim($fqcn, '\\');
+                                        return $target . '::' . $methodName;
                                     }
                                 }
                             }
@@ -276,7 +308,15 @@ class AstUtils
                                     false
                                 );
                                 if ($fqcn !== '') {
-                                    return ltrim($fqcn, '\\') . '::' . $methodName;
+                                    $decl = $this->findDeclaringClassForMethod(
+                                        ltrim($fqcn, '\\'),
+                                        $methodName,
+                                        $callerFuncOrMethodNode,
+                                        $callerNamespace,
+                                        $callerUseMap
+                                    );
+                                    $target = $decl ?? ltrim($fqcn, '\\');
+                                    return $target . '::' . $methodName;
                                 }
                             } elseif ($stmt->type instanceof NullableType && $stmt->type->type instanceof Name) {
                                 $fqcn = $this->resolveNameNodeToFqcn(
@@ -286,7 +326,15 @@ class AstUtils
                                     false
                                 );
                                 if ($fqcn !== '') {
-                                    return ltrim($fqcn, '\\') . '::' . $methodName;
+                                    $decl = $this->findDeclaringClassForMethod(
+                                        ltrim($fqcn, '\\'),
+                                        $methodName,
+                                        $callerFuncOrMethodNode,
+                                        $callerNamespace,
+                                        $callerUseMap
+                                    );
+                                    $target = $decl ?? ltrim($fqcn, '\\');
+                                    return $target . '::' . $methodName;
                                 }
                             }
                         }
@@ -322,7 +370,15 @@ class AstUtils
                                     $fqcn = '';
                                 }
                                 if ($fqcn !== '') {
-                                    return ltrim($fqcn, '\\') . '::' . $methodName;
+                                    $decl = $this->findDeclaringClassForMethod(
+                                        ltrim($fqcn, '\\'),
+                                        $methodName,
+                                        $callerFuncOrMethodNode,
+                                        $callerNamespace,
+                                        $callerUseMap
+                                    );
+                                    $target = $decl ?? ltrim($fqcn, '\\');
+                                    return $target . '::' . $methodName;
                                 }
                             }
                         }
@@ -377,7 +433,15 @@ class AstUtils
 
                     if ($paramFqcn !== '' && $paramFqcn !== '0') {
                         // Successfully mapped $oneMoreClass → FQCN
-                        return ltrim($paramFqcn, '\\') . '::' . $methodName;
+                        $decl = $this->findDeclaringClassForMethod(
+                            ltrim($paramFqcn, '\\'),
+                            $methodName,
+                            $callerFuncOrMethodNode,
+                            $callerNamespace,
+                            $callerUseMap
+                        );
+                        $target = $decl ?? ltrim($paramFqcn, '\\');
+                        return $target . '::' . $methodName;
                     }
                 }
             }
@@ -437,7 +501,15 @@ class AstUtils
                             false
                         );
                         if ($classFqcn !== '' && $classFqcn !== '0') {
-                            return ltrim($classFqcn, '\\') . '::' . $methodName;
+                            $decl = $this->findDeclaringClassForMethod(
+                                ltrim($classFqcn, '\\'),
+                                $methodName,
+                                $callerFuncOrMethodNode,
+                                $callerNamespace,
+                                $callerUseMap
+                            );
+                            $target = $decl ?? ltrim($classFqcn, '\\');
+                            return $target . '::' . $methodName;
                         }
                     }
                 }
@@ -521,6 +593,18 @@ class AstUtils
                     $exists = $ref->hasMethod($methodName);
                 } catch (\ReflectionException $e) {
                     $exists = false;
+                }
+            }
+            if (!$exists) {
+                $decl = $this->findDeclaringClassForMethod(
+                    ltrim($classFqcn, '\\'),
+                    $methodName,
+                    $callerFuncOrMethodNode,
+                    $callerNamespace,
+                    $callerUseMap
+                );
+                if ($decl !== null) {
+                    return $decl . '::' . $methodName;
                 }
             }
 
@@ -770,52 +854,27 @@ class AstUtils
         ?string $callerNamespace,
         array $callerUseMap
     ): ?string {
-        if (class_exists($classFqcn, false)) {
-            try {
-                $ref = new \ReflectionClass($classFqcn);
-                while ($ref) {
-                    if ($ref->hasMethod($method)) {
-                        $decl = $ref->getMethod($method)->getDeclaringClass()->getName();
-                        return ltrim($decl, '\\');
-                    }
-                    $ref = $ref->getParentClass();
-                }
-            } catch (\ReflectionException $e) {
-                // ignore and fall back to AST
-            }
-        }
-
-        $classNode = $callerFuncOrMethodNode->getAttribute('parent');
-        while ($classNode && !$classNode instanceof Node\Stmt\Class_) {
-            $classNode = $classNode->getAttribute('parent');
-        }
-
-        while ($classNode instanceof Node\Stmt\Class_ && $classNode->extends instanceof Node\Name) {
-            $parentFqcn = $this->resolveNameNodeToFqcn($classNode->extends, $callerNamespace, $callerUseMap, false);
-            $candidateKey = ltrim($parentFqcn, '\\') . '::' . $method;
+        $current = $classFqcn;
+        while ($current !== null && $current !== '') {
+            $candidateKey = ltrim($current, '\\') . '::' . $method;
             if (isset(GlobalCache::$astNodeMap[$candidateKey])) {
-                return ltrim($parentFqcn, '\\');
+                return ltrim($current, '\\');
             }
-            if (class_exists($parentFqcn, false)) {
+            if (class_exists($current, false)) {
                 try {
-                    $ref = new \ReflectionClass($parentFqcn);
+                    $ref = new \ReflectionClass($current);
                     if ($ref->hasMethod($method)) {
                         return ltrim($ref->getMethod($method)->getDeclaringClass()->getName(), '\\');
                     }
-                    $classNode = null;
-                    if ($ref->getParentClass()) {
-                        $parentFqcn = $ref->getParentClass()->getName();
-                        $candidateKey = ltrim($parentFqcn, '\\') . '::' . $method;
-                        if (isset(GlobalCache::$astNodeMap[$candidateKey])) {
-                            return ltrim($parentFqcn, '\\');
-                        }
-                    }
+                    $parent = $ref->getParentClass();
+                    $current = $parent ? $parent->getName() : null;
+                    continue;
                 } catch (\ReflectionException $e) {
+                    $current = null;
                     break;
                 }
-            } else {
-                break;
             }
+            $current = GlobalCache::$classParents[$current] ?? null;
         }
 
         return null;

--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -39,6 +39,10 @@ class GlobalCache
      */
     public static $resolvedThrows = [];
     /**
+     * @var array<string,string|null> Mapping of class FQCN to its parent class FQCN
+     */
+    public static $classParents = [];
+    /**
      * @var array<string,array<string,string[]>> Mapping of method key to
      * exception FQCN to a list of origin call chain strings. For each method,
      * each chain starts with the call site location within that method,
@@ -60,5 +64,6 @@ class GlobalCache
         self::$nodeKeyToFilePath = [];
         self::$resolvedThrows = [];
         self::$throwOrigins = [];
+        self::$classParents = [];
     }
 }

--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -87,6 +87,23 @@ class ThrowsGatherer extends NodeVisitorAbstract
      */
     public function enterNode($node)
     {
+        if ($node instanceof Node\Stmt\Class_) {
+            $className = '';
+            if ($node->hasAttribute('namespacedName') && $node->getAttribute('namespacedName') instanceof Node\Name) {
+                $className = $node->getAttribute('namespacedName')->toString();
+            } elseif ($node->name) {
+                $className = ($this->currentNamespace ? $this->currentNamespace . '\\' : '') . $node->name->toString();
+            }
+            if ($className !== '') {
+                $parentFqcn = null;
+                if ($node->extends instanceof Node\Name) {
+                    $parentFqcn = $this->astUtils->resolveNameNodeToFqcn($node->extends, $this->currentNamespace, $this->useMap, false);
+                }
+                \HenkPoley\DocBlockDoctor\GlobalCache::$classParents[$className] = $parentFqcn;
+            }
+            return null;
+        }
+
         if (!$node instanceof Node\Stmt\Function_ && !$node instanceof Node\Stmt\ClassMethod) {
             return null;
         }

--- a/tests/fixtures/method-in-parent-class/MethodInParentClass/Caller.php
+++ b/tests/fixtures/method-in-parent-class/MethodInParentClass/Caller.php
@@ -1,0 +1,10 @@
+<?php
+namespace Pitfalls\MethodInParentClass;
+
+class Caller
+{
+    public function callChildClassWithMethodInParent(ChildClass $child): void
+    {
+        $child->methodInParent();
+    }
+}

--- a/tests/fixtures/method-in-parent-class/MethodInParentClass/ChildClass.php
+++ b/tests/fixtures/method-in-parent-class/MethodInParentClass/ChildClass.php
@@ -1,0 +1,6 @@
+<?php
+namespace Pitfalls\MethodInParentClass;
+
+class ChildClass extends ParentClass
+{
+}

--- a/tests/fixtures/method-in-parent-class/MethodInParentClass/ParentClass.php
+++ b/tests/fixtures/method-in-parent-class/MethodInParentClass/ParentClass.php
@@ -1,0 +1,14 @@
+<?php
+namespace Pitfalls\MethodInParentClass;
+
+class ParentClass
+{
+    /**
+     * @throws \LogicException
+     */
+    public function methodInParent(): void
+    {
+        throw new \LogicException();
+    }
+}
+

--- a/tests/fixtures/method-in-parent-class/expected_results.json
+++ b/tests/fixtures/method-in-parent-class/expected_results.json
@@ -1,10 +1,10 @@
 {
   "fullyQualifiedMethodKeys": {
-    "Pitfalls\\MethodInParentClass\\Caller::callChildClassWithMethodInParent": [
+    "Pitfalls\\MethodInParentClass\\ParentClass::methodInParent": [
       "LogicException"
     ],
-    "Pitfalls\\MethodChaining\\Caller::callRuntimeException": [
-      "RuntimeException"
+    "Pitfalls\\MethodInParentClass\\Caller::callChildClassWithMethodInParent": [
+      "LogicException"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- track class inheritance while traversing code
- resolve callee methods defined in parent classes
- add fixture for calling a parent's method

## Testing
- `./vendor/bin/phpunit -c phpunit.xml --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684411d3bfe083288dda2115b1735455