### PR TITLE
Add nullable return chain coverage

### DIFF
--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -332,4 +332,73 @@ class AstUtilsTest extends TestCase
         $resolved = $this->astUtils->getCalleeKey($call, 'M', [], $use);
         $this->assertSame('M\\Assert::__callStatic', $resolved);
     }
+
+    /**
+     * @throws \LogicException
+     */
+    public function testResolveMethodChainNullableReturn(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace X;
+
+        class Factory {
+            public function maybe(): ?Product {
+                return new Product();
+            }
+        }
+
+        class Product {
+            public function work(): void {}
+        }
+
+        class Caller {
+            private Factory $f;
+
+            public function __construct(Factory $f) {
+                $this->f = $f;
+            }
+
+            public function run(): void {
+                $this->f->maybe()->work();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $run = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'run');
+        $this->assertNotNull($run);
+        $calls = $this->finder->findInstanceOf($run->stmts, Node\Expr\MethodCall::class);
+        $targetCall = null;
+        foreach ($calls as $c) {
+            if ($c->name instanceof Node\Identifier && $c->name->toString() === 'work') {
+                $targetCall = $c;
+                break;
+            }
+        }
+        $this->assertNotNull($targetCall);
+        $resolved = $this->astUtils->getCalleeKey($targetCall, 'X', [], $run);
+        $this->assertSame('X\\Product::work', $resolved);
+    }
 }

--- a/tests/fixtures/method-chaining-nullable/ChainNullable.php
+++ b/tests/fixtures/method-chaining-nullable/ChainNullable.php
@@ -1,0 +1,28 @@
+<?php
+// tests/fixtures/method-chaining-nullable/ChainNullable.php
+namespace Pitfalls\MethodChainingNullable;
+
+class Factory {
+    public function maybe(): ?Product {
+        return new Product();
+    }
+}
+
+class Product {
+    public function doWork(): void {
+        throw new \RuntimeException("uh-oh");
+    }
+}
+
+class Caller {
+    /** @var Factory */
+    private $factory;
+
+    public function __construct(Factory $f) {
+        $this->factory = $f;
+    }
+
+    public function runAll(): void {
+        $this->factory->maybe()->doWork();
+    }
+}

--- a/tests/fixtures/method-chaining-nullable/expected_results.json
+++ b/tests/fixtures/method-chaining-nullable/expected_results.json
@@ -1,0 +1,11 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\MethodChainingNullable\\Factory::maybe": [],
+    "Pitfalls\\MethodChainingNullable\\Product::doWork": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\MethodChainingNullable\\Caller::runAll": [
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- cover resolving chained method call when inner call has a nullable return type
- add fixture for nullable-return method chain

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6844347133588328ab92abd953898791