### PR TITLE
Add coverage for AstUtils return-new handling

### DIFF
--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -401,4 +401,72 @@ class AstUtilsTest extends TestCase
         $resolved = $this->astUtils->getCalleeKey($targetCall, 'X', [], $run);
         $this->assertSame('X\\Product::work', $resolved);
     }
+    /**
+     * @throws \LogicException
+     */
+    public function testResolveMethodChainReturnNew(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace Y;
+
+        class Factory {
+            public function create() {
+                return new Product();
+            }
+        }
+
+        class Product {
+            public function work(): void {}
+        }
+
+        class Caller {
+            private Factory $f;
+
+            public function __construct(Factory $f) {
+                $this->f = $f;
+            }
+
+            public function run(): void {
+                $this->f->create()->work();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $run = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'run');
+        $this->assertNotNull($run);
+        $calls = $this->finder->findInstanceOf($run->stmts, Node\Expr\MethodCall::class);
+        $targetCall = null;
+        foreach ($calls as $c) {
+            if ($c->name instanceof Node\Identifier && $c->name->toString() === 'work') {
+                $targetCall = $c;
+                break;
+            }
+        }
+        $this->assertNotNull($targetCall);
+        $resolved = $this->astUtils->getCalleeKey($targetCall, 'Y', [], $run);
+        $this->assertSame('Y\\Product::work', $resolved);
+    }
 }

--- a/tests/fixtures/method-chaining-notype/ChainNoType.php
+++ b/tests/fixtures/method-chaining-notype/ChainNoType.php
@@ -1,0 +1,30 @@
+<?php
+// tests/fixtures/method-chaining-notype/ChainNoType.php
+namespace Pitfalls\MethodChainingNoType;
+
+class Factory {
+    public function build() {
+        return new Product();
+    }
+}
+
+class Product {
+    /**
+     */
+    public function doWork(): void {
+        throw new \RuntimeException("uh-oh");
+    }
+}
+
+class Caller {
+    /** @var Factory */
+    private $factory;
+
+    public function __construct(Factory $f) {
+        $this->factory = $f;
+    }
+
+    public function runAll(): void {
+        $this->factory->build()->doWork();
+    }
+}

--- a/tests/fixtures/method-chaining-notype/expected_results.json
+++ b/tests/fixtures/method-chaining-notype/expected_results.json
@@ -1,0 +1,11 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\MethodChainingNoType\\Factory::build": [],
+    "Pitfalls\\MethodChainingNoType\\Product::doWork": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\MethodChainingNoType\\Caller::runAll": [
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add test covering method chain when inner method returns new object without type hint
- add fixture for chaining without return type

## Testing
- `./vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6844361976bc8328a1d6bb0cc22316bc