### PR TITLE
Add test for nullable property type

### DIFF
--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -231,6 +231,59 @@ class AstUtilsTest extends TestCase
     /**
      * @throws \LogicException
      */
+    public function testResolveNullableTypedPropertyCall(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace PN;
+
+        class Q {
+            private ?R $r;
+
+            public function __construct() {
+                $this->r = new R();
+            }
+
+            public function foo(): void {
+                $this->r->bar();
+            }
+        }
+
+        class R { public function bar(): void {} }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $foo = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'foo');
+        $this->assertNotNull($foo);
+        $call = $this->finder->findFirstInstanceOf($foo->stmts, Node\Expr\MethodCall::class);
+        $resolved = $this->astUtils->getCalleeKey($call, 'PN', [], $foo);
+        $this->assertSame('PN\\R::bar', $resolved);
+    }
+
+    /**
+     * @throws \LogicException
+     */
     public function testResolveTraitPropertyCall(): void
     {
         $code = <<<'PHP'

--- a/tests/fixtures/property-nullable-type/Template.php
+++ b/tests/fixtures/property-nullable-type/Template.php
@@ -1,0 +1,44 @@
+<?php
+namespace Pitfalls\PropertyNullableType;
+
+class Template
+{
+    private ?Translate $translator;
+
+    public function __construct()
+    {
+        $this->translator = new Translate();
+    }
+
+    public function getEntityPropertyTranslation(): void
+    {
+        $this->translator->getLanguage()->getPreferredLanguages();
+    }
+}
+
+class Translate
+{
+    private Language $language;
+
+    public function __construct()
+    {
+        $this->language = new Language();
+    }
+
+    public function getLanguage(): Language
+    {
+        return $this->language;
+    }
+}
+
+class Language
+{
+    /**
+     * @throws \ArithmeticError
+     * @return array
+     */
+    public function getPreferredLanguages(): array
+    {
+        throw new \ArithmeticError();
+    }
+}

--- a/tests/fixtures/property-nullable-type/expected_results.json
+++ b/tests/fixtures/property-nullable-type/expected_results.json
@@ -1,0 +1,7 @@
+{
+  "fullyQualifiedMethodKeys" :{
+    "Pitfalls\\PropertyNullableType\\Template::getEntityPropertyTranslation": [
+      "ArithmeticError"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add new fixture for classes with nullable typed property
- test AstUtils getCalleeKey handles nullable property types

## Testing
- `vendor/bin/phpunit -c phpunit.xml --testsuite Unit --filter testResolveNullableTypedPropertyCall --colors=never`
- `vendor/bin/phpunit -c phpunit.xml --testsuite Unit --colors=never`
- `vendor/bin/phpunit -c phpunit.xml --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_684438bb0fac8328bf6ad5b0b6792d3a