### PR TITLE
Add coverage for nullable parameter resolution

### DIFF
--- a/tests/fixtures/parameter-nullable-type/Template.php
+++ b/tests/fixtures/parameter-nullable-type/Template.php
@@ -1,0 +1,17 @@
+<?php
+namespace Pitfalls\ParameterNullableType;
+
+class Worker {
+    /**
+     * @throws \RuntimeException
+     */
+    public function doWork(): void {
+        throw new \RuntimeException("fail");
+    }
+}
+
+class Processor {
+    public function run(?Worker $worker): void {
+        $worker->doWork();
+    }
+}

--- a/tests/fixtures/parameter-nullable-type/expected_results.json
+++ b/tests/fixtures/parameter-nullable-type/expected_results.json
@@ -1,0 +1,10 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\ParameterNullableType\\Worker::doWork": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\ParameterNullableType\\Processor::run": [
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add new `parameter-nullable-type` fixture for integration testing
- test nullable parameter type resolution and ignore scalar parameters in `AstUtils`

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68443c491b9483289afea6ba59efc864