### PR TITLE
Add tests for parent static call resolution

### DIFF
--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -663,4 +663,110 @@ class AstUtilsTest extends TestCase
         $resolved = $this->astUtils->getCalleeKey($targetCall, 'Y', [], $run);
         $this->assertSame('Y\\Product::work', $resolved);
     }
+
+    /**
+     * @throws \LogicException
+     */
+    public function testResolveParentStaticCallFallback(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace Pitfalls\ParentMethodCall;
+
+        class ParentClass {
+            /**
+             * @throws \RuntimeException
+             */
+            public function foo(): void {
+                throw new \RuntimeException();
+            }
+        }
+
+        class ChildClass extends ParentClass {
+            public function callFoo(): void {
+                parent::foo();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $callFoo = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'callFoo');
+        $this->assertNotNull($callFoo);
+        $call = $this->finder->findFirstInstanceOf($callFoo->stmts, Node\Expr\StaticCall::class);
+        $this->assertNotNull($call);
+        $resolved = $this->astUtils->getCalleeKey($call, 'Pitfalls\\ParentMethodCall', [], $callFoo);
+        $this->assertSame('Pitfalls\\ParentMethodCall\\ParentClass::foo', $resolved);
+    }
+
+    /**
+     * @throws \LogicException
+     */
+    public function testResolveParentStaticCallWithResolvedName(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace Pitfalls\ParentMethodCall;
+
+        class ParentClass {
+            public function foo(): void {}
+        }
+
+        class ChildClass extends ParentClass {
+            public function callFoo(): void {
+                parent::foo();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $callFoo = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'callFoo');
+        $this->assertNotNull($callFoo);
+        $call = $this->finder->findFirstInstanceOf($callFoo->stmts, Node\Expr\StaticCall::class);
+        $this->assertNotNull($call);
+        $call->class->setAttribute('resolvedName', new Node\Name\FullyQualified('Pitfalls\\ParentMethodCall\\ParentClass'));
+        $resolved = $this->astUtils->getCalleeKey($call, 'Pitfalls\\ParentMethodCall', [], $callFoo);
+        $this->assertSame('Pitfalls\\ParentMethodCall\\ParentClass::foo', $resolved);
+    }
 }

--- a/tests/fixtures/parent-method-call/ParentMethodCall.php
+++ b/tests/fixtures/parent-method-call/ParentMethodCall.php
@@ -1,0 +1,21 @@
+<?php
+namespace Pitfalls\ParentMethodCall;
+
+class ParentClass
+{
+    /**
+     * @throws \RuntimeException
+     */
+    public function foo(): void
+    {
+        throw new \RuntimeException();
+    }
+}
+
+class ChildClass extends ParentClass
+{
+    public function callFoo(): void
+    {
+        parent::foo();
+    }
+}

--- a/tests/fixtures/parent-method-call/expected_results.json
+++ b/tests/fixtures/parent-method-call/expected_results.json
@@ -1,0 +1,10 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\ParentMethodCall\\ParentClass::foo": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\ParentMethodCall\\ChildClass::callFoo": [
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add fixture for parent static method calls
- test `AstUtils::getCalleeKey` resolves `parent::method()`
- ensure both resolvedName and fallback paths are covered

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml --dont-report-useless-tests tests/Unit/AstUtilsTest.php`
- `vendor/bin/phpunit --configuration phpunit.xml --dont-report-useless-tests`

------
https://chatgpt.com/codex/tasks/task_e_68443e442494832885b5b30cbff6e9e2