### PR TITLE
Add ignore-annotated-throws option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Options:
   --write-dirs=DIRS  Comma-separated list of directories that may be modified (default: src)
   --trace-throw-origins  Replace @throws descriptions with origin locations and call chain
   --trace-throw-call-sites  Replace @throws descriptions with call site line numbers
+  --ignore-annotated-throws Ignore existing @throws annotations when analyzing
 ```
 
 ## Result
@@ -60,7 +61,7 @@ Options:
 
 Thrown exceptions and `@throws` annotations bubble up along the call chain. It tracks direct function calls, function calls from object variables, and class instantiation. It sorts the exceptions, and de-duplicates them. Exception classes that do not exist, do not propagate along the call chain.
 
-It cannot track runtime dynamically attached class functions. To compensate it just believes any `@throws` that are already annotated. Sadly the `@method` annotation for "Laravel Facade"-like cannot specify thrown exceptions, it is not in the spec, so good luck. Maybe submit a patch if you know how to fix this for specific use cases. By blindly believing existing annotations, this also means we cannot automatically clean up old exceptions that are no longer thrown.
+It cannot track runtime dynamically attached class functions. To compensate it normally believes any `@throws` that are already annotated. Sadly the `@method` annotation for "Laravel Facade"-like cannot specify thrown exceptions, it is not in the spec, so good luck. With the `--ignore-annotated-throws` option you can disable this behaviour and clean out stale annotations.
 
 ## Dependencies
 
@@ -77,7 +78,6 @@ Had a crashing "single"-sign-on system that uses costomisations of [SimpleSAMLph
 ## TODO
 
 * Handle PHP 'magic' such as Laravel Facades.
-* Make an option to ignore existing `@throws` annotations (apart from the multi-line comments), so it can clean up the docblocks. Erasing 'Laravel Facade'-like `@throws` of course.
 * Maybe put the `use` statement cleaning behind some commandline option.
 * Propagate (full function-wide) `catch(\Specific\Exception $e)` through the call chain. We can be fairly sure that part of the code won't emit that exception. So you have at least some basic way to clean up the `@throws` annotations.
 * Follow proper ordering of PhpDoc tags. If there is one? @return comes before @throws. @see comes after @throws?

--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -14,6 +14,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
     private \PhpParser\NodeFinder $nodeFinder;
     private \HenkPoley\DocBlockDoctor\AstUtils $astUtils;
     private string $filePath;
+    private bool $ignoreAnnotatedThrows;
     /**
      * @var string
      */
@@ -23,11 +24,12 @@ class ThrowsGatherer extends NodeVisitorAbstract
      */
     private array $useMap = [];
 
-    public function __construct(NodeFinder $nodeFinder, \HenkPoley\DocBlockDoctor\AstUtils $astUtils, string $filePath)
+    public function __construct(NodeFinder $nodeFinder, \HenkPoley\DocBlockDoctor\AstUtils $astUtils, string $filePath, bool $ignoreAnnotatedThrows = false)
     {
         $this->nodeFinder = $nodeFinder;
         $this->astUtils = $astUtils;
         $this->filePath = $filePath;
+        $this->ignoreAnnotatedThrows = $ignoreAnnotatedThrows;
     }
 
     /**
@@ -154,7 +156,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
                     $resolvedFqcnForAnnotation = $this->astUtils->resolveStringToFqcn($exceptionNameInAnnotation, $this->currentNamespace, $this->useMap);
                     $currentThrowsFqcnForDesc = $resolvedFqcnForAnnotation;
                     $accumulatedDescription = trim($matches[2]);
-                    if ($resolvedFqcnForAnnotation !== '' && $resolvedFqcnForAnnotation !== '0') {
+                    if ($resolvedFqcnForAnnotation !== '' && $resolvedFqcnForAnnotation !== '0' && !$this->ignoreAnnotatedThrows) {
                         $currentAnnotatedThrowsFqcns[] = $resolvedFqcnForAnnotation;
                     }
 

--- a/tests/fixtures/ignore-throws-annotations/ThrowsInConstructor.php
+++ b/tests/fixtures/ignore-throws-annotations/ThrowsInConstructor.php
@@ -1,0 +1,37 @@
+<?php
+// tests/fixtures/constructor-throws/ThrowsInConstructor.php
+
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\TestFixtures\ConstructorThrows;
+
+class ThrowsInConstructor
+{
+    public function __construct()
+    {
+        throw new \LogicException("fail");
+    }
+
+    /**
+     * We annotate an exception that's not actually thrown here to make sure we 'believe' that.
+     * @throws \RuntimeException
+     */
+    public function createAndCall()
+    {
+        $obj = new ThrowsInConstructor();
+        $obj->someMethod();
+    }
+
+    public function createAndCallWithForeach()
+    {
+        $obj = new ThrowsInConstructor();
+        foreach (['a', 'b'] as $key => $value) {
+            $obj->someMethod($value);
+        }
+    }
+
+    public function someMethod(): void
+    {
+        // no throw here
+    }
+}

--- a/tests/fixtures/ignore-throws-annotations/expected_results.json
+++ b/tests/fixtures/ignore-throws-annotations/expected_results.json
@@ -1,0 +1,14 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ConstructorThrows\\ThrowsInConstructor::__construct": [
+      "LogicException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ConstructorThrows\\ThrowsInConstructor::createAndCall": [
+      "LogicException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ConstructorThrows\\ThrowsInConstructor::createAndCallWithForeach": [
+      "LogicException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\ConstructorThrows\\ThrowsInConstructor::someMethod": []
+  }
+}


### PR DESCRIPTION
## Summary
- add `--ignore-annotated-throws` CLI flag
- collect ThrowsGatherer option to skip trusting docblock annotations
- adjust Application flow and tests for new option
- document new option in README
- include fixture for ignoring annotated throws

## Testing
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684445e53e4483288639ca10a61e9f34