### PR TITLE
Handle static calls via properties

### DIFF
--- a/tests/fixtures/property-static-call/SubjectStaticPropertyCall.php
+++ b/tests/fixtures/property-static-call/SubjectStaticPropertyCall.php
@@ -1,0 +1,21 @@
+<?php
+// tests/fixtures/property-static-call/SubjectStaticPropertyCall.php
+namespace Pitfalls\PropertyStaticCall;
+
+class Logger {
+    public static function warning(): void {
+        throw new \RuntimeException('fail');
+    }
+}
+
+class SubjectID {
+    /**
+     * @var Logger|string
+     * @psalm-var Logger|class-string
+     */
+    protected $logger = Logger::class;
+
+    public function doCall(): void {
+        $this->logger::warning();
+    }
+}

--- a/tests/fixtures/property-static-call/expected_results.json
+++ b/tests/fixtures/property-static-call/expected_results.json
@@ -1,0 +1,10 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\PropertyStaticCall\\Logger::warning": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\PropertyStaticCall\\SubjectID::doCall": [
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- handle union types when resolving strings to FQCNs
- support `$this->prop::method()` calls when tracking throw origins
- add integration fixture for property static calls

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68445bd385a08328bbb9b8c2ec0f5f37