### PR TITLE
Handle static-call returned objects

### DIFF
--- a/tests/fixtures/static-call-returned-object/StaticCallReturned.php
+++ b/tests/fixtures/static-call-returned-object/StaticCallReturned.php
@@ -1,0 +1,27 @@
+<?php
+namespace Pitfalls\StaticCallReturnedObject;
+
+class Provider {
+    /**
+     * @return Handler
+     */
+    public static function getHandler(): Handler {
+        return new Handler();
+    }
+}
+
+class Handler {
+    public function handle(): void {
+        throw new \RuntimeException('fail');
+    }
+}
+
+class Runner {
+    public function run(): void {
+        $h = Provider::getHandler();
+        $h->handle();
+    }
+    public function runDirect(): void {
+        Provider::getHandler()->handle();
+    }
+}

--- a/tests/fixtures/static-call-returned-object/expected_results.json
+++ b/tests/fixtures/static-call-returned-object/expected_results.json
@@ -1,0 +1,14 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\StaticCallReturnedObject\\Provider::getHandler": [],
+    "Pitfalls\\StaticCallReturnedObject\\Handler::handle": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\StaticCallReturnedObject\\Runner::run": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\StaticCallReturnedObject\\Runner::runDirect": [
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- handle method calls on objects returned from static method calls
- add fixture for static call returning an object

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68446e544d9c8328805a68c6b9bbefb0