### PR TITLE
Propagate exceptions via assigned call return types

### DIFF
--- a/src/AstUtils.php
+++ b/src/AstUtils.php
@@ -19,6 +19,66 @@ use Composer\Autoload\ClassLoader;
 class AstUtils
 {
     /**
+     * Cache of variable assignments for each function/method node.
+     *
+     * @var array<string,array<string,array<int,array{pos:int,expr:Node\Expr}>>>
+     */
+    private array $assignmentCache = [];
+
+    /**
+     * Build or retrieve cached assignments for the given function/method.
+     *
+     * @param Node\FunctionLike $func
+     * @return array<string,array<int,array{pos:int,expr:Node\Expr}>>
+     */
+    private function getAssignmentsForFunction(Node\FunctionLike $func): array
+    {
+        $key = spl_object_hash($func);
+        if (!isset($this->assignmentCache[$key])) {
+            $map = [];
+            /** @psalm-suppress NoInterfaceProperties */
+            if (property_exists($func, 'stmts') && is_array($func->stmts)) {
+                $finder = new NodeFinder();
+                $assigns = $finder->findInstanceOf($func->stmts, Assign::class);
+                foreach ($assigns as $assign) {
+                    if ($assign->var instanceof Variable && is_string($assign->var->name)) {
+                        $map[$assign->var->name][] = [
+                            'pos'  => $assign->getStartFilePos(),
+                            'expr' => $assign->expr,
+                        ];
+                    }
+                }
+            }
+            $this->assignmentCache[$key] = $map;
+        }
+        return $this->assignmentCache[$key];
+    }
+
+    /**
+     * Find the expression assigned to $varName before the given call position.
+     *
+     * @param string $varName
+     * @param Node $callNode
+     * @param Node\FunctionLike $func
+     */
+    private function findPriorAssignment(string $varName, Node $callNode, Node\FunctionLike $func): ?Node\Expr
+    {
+        $assignments = $this->getAssignmentsForFunction($func)[$varName] ?? [];
+        $callPos = $callNode->getStartFilePos();
+        $bestPos = -1;
+        $bestExpr = null;
+        foreach ($assignments as $info) {
+            if ($info['expr'] === $callNode) {
+                continue;
+            }
+            if ($info['pos'] < $callPos && $info['pos'] > $bestPos) {
+                $bestPos = $info['pos'];
+                $bestExpr = $info['expr'];
+            }
+        }
+        return $bestExpr;
+    }
+    /**
      * @param \PhpParser\Node $node
      * @param string $currentNamespace
      */
@@ -680,73 +740,7 @@ class AstUtils
             }
         }
 
-        // === LOCAL NEW ASSIGNMENT:  $foo = new SomeClass();  then  $foo->bar()  ===
-        if (
-            $callNode instanceof Node\Expr\MethodCall
-            && $callNode->var instanceof Variable
-            && is_string($callNode->var->name)
-            && $callNode->name instanceof Identifier
-        ) {
-            $varName    = $callNode->var->name;     // e.g. "foo"
-            $methodName = $callNode->name->toString();
-
-            // Ensure we have statements to scan:
-            /** @psalm-suppress NoInterfaceProperties */
-            if (property_exists($callerFuncOrMethodNode, 'stmts') && is_array($callerFuncOrMethodNode->stmts)) {
-                $finder     = new NodeFinder();
-                $allAssigns = $finder->findInstanceOf(
-                    $callerFuncOrMethodNode->stmts,
-                    Assign::class
-                );
-
-                $bestAssign   = null;
-                $bestPosition = -1;
-                foreach ($allAssigns as $assignNode) {
-                    // match "$foo = new Something();"
-                    if (
-                        $assignNode->var instanceof Variable
-                        && is_string($assignNode->var->name)
-                        && $assignNode->var->name === $varName
-                        && $assignNode->expr instanceof Node\Expr\New_
-                        && $assignNode->expr->class instanceof Node\Name
-                    ) {
-                        $pos = $assignNode->getStartFilePos();
-                        $callPos = $callNode->getStartFilePos();
-                        // Only consider assignments that happen earlier in the file than the call:
-                        if ($pos < $callPos && $pos > $bestPosition) {
-                            $bestPosition = $pos;
-                            $bestAssign   = $assignNode;
-                        }
-                    }
-                }
-
-                if ($bestAssign instanceof Assign) {
-                    // Resolve "new Something()" → FQCN
-                    /** @var Node\Expr\New_ $newExpr */
-                    $newExpr = $bestAssign->expr;
-                    if ($newExpr->class instanceof Node\Name) {
-                        $newClassNode = $newExpr->class;
-                        $classFqcn    = $this->resolveNameNodeToFqcn(
-                            $newClassNode,
-                            $callerNamespace,
-                            $callerUseMap,
-                            false
-                        );
-                        if ($classFqcn !== '' && $classFqcn !== '0') {
-                            $decl = $this->findDeclaringClassForMethod(
-                                ltrim($classFqcn, '\\'),
-                                $methodName
-                            );
-                            $target = $decl ?? ltrim($classFqcn, '\\');
-                            return $target . '::' . $methodName;
-                        }
-                    }
-                }
-            }
-            // If nothing matched, fall through to "$this->", "static::", etc.
-        }
-
-        // === LOCAL CALL ASSIGNMENT: $foo = SomeClass::factory(); then $foo->bar() ===
+        // === LOCAL ASSIGNMENT: variable initialized from "new" or another call ===
         if (
             $callNode instanceof Node\Expr\MethodCall
             && $callNode->var instanceof Variable
@@ -756,99 +750,80 @@ class AstUtils
             $varName    = $callNode->var->name;
             $methodName = $callNode->name->toString();
 
-            /** @psalm-suppress NoInterfaceProperties */
-            if (property_exists($callerFuncOrMethodNode, 'stmts') && is_array($callerFuncOrMethodNode->stmts)) {
-                $finder     = new NodeFinder();
-                $allAssigns = $finder->findInstanceOf(
-                    $callerFuncOrMethodNode->stmts,
-                    Assign::class
+            $assignedExpr = $this->findPriorAssignment($varName, $callNode, $callerFuncOrMethodNode);
+
+            if ($assignedExpr instanceof Node\Expr\New_ && $assignedExpr->class instanceof Node\Name) {
+                $classFqcn = $this->resolveNameNodeToFqcn(
+                    $assignedExpr->class,
+                    $callerNamespace,
+                    $callerUseMap,
+                    false
                 );
-
-                $bestAssign   = null;
-                $bestPosition = -1;
-                foreach ($allAssigns as $assignNode) {
-                    if (
-                        $assignNode->var instanceof Variable
-                        && is_string($assignNode->var->name)
-                        && $assignNode->var->name === $varName
-                    ) {
-                        $pos     = $assignNode->getStartFilePos();
-                        $callPos = $callNode->getStartFilePos();
-                        if ($pos < $callPos && $pos > $bestPosition) {
-                            $bestPosition = $pos;
-                            $bestAssign   = $assignNode;
-                        }
-                    }
+                if ($classFqcn !== '' && $classFqcn !== '0') {
+                    $decl  = $this->findDeclaringClassForMethod(ltrim($classFqcn, '\\'), $methodName);
+                    $target = $decl ?? ltrim($classFqcn, '\\');
+                    return $target . '::' . $methodName;
                 }
+            } elseif ($assignedExpr instanceof Node\Expr\FuncCall || $assignedExpr instanceof Node\Expr\MethodCall || $assignedExpr instanceof Node\Expr\StaticCall) {
+                $innerKey = $this->getCalleeKey(
+                    $assignedExpr,
+                    $callerNamespace,
+                    $callerUseMap,
+                    $callerFuncOrMethodNode,
+                    $visited
+                );
+                if ($innerKey) {
+                    $innerNode     = GlobalCache::$astNodeMap[$innerKey] ?? null;
+                    $innerFilePath = GlobalCache::$nodeKeyToFilePath[$innerKey] ?? null;
 
-                if ($bestAssign instanceof Assign) {
-                    $expr = $bestAssign->expr;
-                    if (
-                        $expr instanceof Node\Expr\FuncCall ||
-                        $expr instanceof Node\Expr\MethodCall ||
-                        $expr instanceof Node\Expr\StaticCall
-                    ) {
-                        $innerKey = $this->getCalleeKey(
-                            $expr,
-                            $callerNamespace,
-                            $callerUseMap,
-                            $callerFuncOrMethodNode,
-                            $visited
-                        );
-                        if ($innerKey) {
-                            $innerNode     = GlobalCache::$astNodeMap[$innerKey] ?? null;
-                            $innerFilePath = GlobalCache::$nodeKeyToFilePath[$innerKey] ?? null;
+                    if ($innerNode instanceof Node\FunctionLike && $innerFilePath) {
+                        $innerNamespace = GlobalCache::$fileNamespaces[$innerFilePath] ?? '';
+                        $innerUseMap    = GlobalCache::$fileUseMaps[$innerFilePath] ?? [];
 
-                            if ($innerNode instanceof Node\FunctionLike && $innerFilePath) {
-                                $innerNamespace = GlobalCache::$fileNamespaces[$innerFilePath] ?? '';
-                                $innerUseMap    = GlobalCache::$fileUseMaps[$innerFilePath] ?? [];
+                        $returnType = $innerNode->returnType;
+                        if ($returnType instanceof Name) {
+                            $returnedFqcn = $this->resolveNameNodeToFqcn(
+                                $returnType,
+                                $innerNamespace,
+                                $innerUseMap,
+                                false
+                            );
+                            if ($returnedFqcn !== '') {
+                                $decl  = $this->findDeclaringClassForMethod(ltrim($returnedFqcn, '\\'), $methodName);
+                                $target = $decl ?? ltrim($returnedFqcn, '\\');
+                                return $target . '::' . $methodName;
+                            }
+                        } elseif ($returnType instanceof NullableType && $returnType->type instanceof Name) {
+                            $returnedFqcn = $this->resolveNameNodeToFqcn(
+                                $returnType->type,
+                                $innerNamespace,
+                                $innerUseMap,
+                                false
+                            );
+                            if ($returnedFqcn !== '') {
+                                $decl  = $this->findDeclaringClassForMethod(ltrim($returnedFqcn, '\\'), $methodName);
+                                $target = $decl ?? ltrim($returnedFqcn, '\\');
+                                return $target . '::' . $methodName;
+                            }
+                        }
 
-                                $returnType = $innerNode->returnType;
-                                if ($returnType instanceof Name) {
-                                    $returnedFqcn = $this->resolveNameNodeToFqcn(
-                                        $returnType,
-                                        $innerNamespace,
-                                        $innerUseMap,
-                                        false
-                                    );
-                                    if ($returnedFqcn !== '') {
-                                        $decl  = $this->findDeclaringClassForMethod(ltrim($returnedFqcn, '\\'), $methodName);
-                                        $target = $decl ?? ltrim($returnedFqcn, '\\');
-                                        return $target . '::' . $methodName;
-                                    }
-                                } elseif ($returnType instanceof NullableType && $returnType->type instanceof Name) {
-                                    $returnedFqcn = $this->resolveNameNodeToFqcn(
-                                        $returnType->type,
-                                        $innerNamespace,
-                                        $innerUseMap,
-                                        false
-                                    );
-                                    if ($returnedFqcn !== '') {
-                                        $decl  = $this->findDeclaringClassForMethod(ltrim($returnedFqcn, '\\'), $methodName);
-                                        $target = $decl ?? ltrim($returnedFqcn, '\\');
-                                        return $target . '::' . $methodName;
-                                    }
-                                }
-
-                                $finder2 = new NodeFinder();
-                                $returns = $finder2->findInstanceOf($innerNode->stmts ?? [], Return_::class);
-                                foreach ($returns as $returnStmt) {
-                                    if (
-                                        $returnStmt->expr instanceof Node\Expr\New_
-                                        && $returnStmt->expr->class instanceof Name
-                                    ) {
-                                        $returnedFqcn = $this->resolveNameNodeToFqcn(
-                                            $returnStmt->expr->class,
-                                            $innerNamespace,
-                                            $innerUseMap,
-                                            false
-                                        );
-                                        if ($returnedFqcn !== '' && $returnedFqcn !== '0') {
-                                            $decl  = $this->findDeclaringClassForMethod(ltrim($returnedFqcn, '\\'), $methodName);
-                                            $target = $decl ?? ltrim($returnedFqcn, '\\');
-                                            return $target . '::' . $methodName;
-                                        }
-                                    }
+                        $finder2 = new NodeFinder();
+                        $returns = $finder2->findInstanceOf($innerNode->stmts ?? [], Return_::class);
+                        foreach ($returns as $returnStmt) {
+                            if (
+                                $returnStmt->expr instanceof Node\Expr\New_
+                                && $returnStmt->expr->class instanceof Name
+                            ) {
+                                $returnedFqcn = $this->resolveNameNodeToFqcn(
+                                    $returnStmt->expr->class,
+                                    $innerNamespace,
+                                    $innerUseMap,
+                                    false
+                                );
+                                if ($returnedFqcn !== '' && $returnedFqcn !== '0') {
+                                    $decl  = $this->findDeclaringClassForMethod(ltrim($returnedFqcn, '\\'), $methodName);
+                                    $target = $decl ?? ltrim($returnedFqcn, '\\');
+                                    return $target . '::' . $methodName;
                                 }
                             }
                         }

--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -231,6 +231,61 @@ class AstUtilsTest extends TestCase
     }
 
     /**
+     * Ensure that a variable assigned from a call on itself does not cause infinite recursion.
+     *
+     * @throws \LogicException
+     */
+    public function testSelfAssignmentDoesNotRecurse(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace FooSelf;
+
+        class C {
+            public function create(): C { return new C(); }
+            public function bar(): void {}
+
+            public function test(): void {
+                $c = new C();
+                $c = $c->create();
+                $c->bar();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $testMethod = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'test');
+        $this->assertNotNull($testMethod);
+        $call = $this->finder->findFirst(
+            $testMethod->stmts,
+            fn(Node $n) => $n instanceof Node\Expr\MethodCall && $n->name instanceof Node\Identifier && $n->name->toString() === 'bar'
+        );
+        $resolved = $this->astUtils->getCalleeKey($call, 'FooSelf', [], $testMethod);
+        $this->assertSame('FooSelf\\C::bar', $resolved);
+    }
+
+    /**
      * @throws \LogicException
      */
     public function testResolvePromotedPropertyCall(): void

--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -182,6 +182,57 @@ class AstUtilsTest extends TestCase
     /**
      * @throws \LogicException
      */
+    public function testResolveAssignedFromCall(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace Foo;
+
+        class C {
+            public static function create(): C { return new C(); }
+            public function bar(): void {}
+        }
+
+        class T {
+            public function test(): void {
+                $c = C::create();
+                $c->bar();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $testMethod = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'test');
+        $this->assertNotNull($testMethod);
+        $call = $this->finder->findFirstInstanceOf($testMethod->stmts, Node\Expr\MethodCall::class);
+        $resolved = $this->astUtils->getCalleeKey($call, 'Foo', [], $testMethod);
+        $this->assertSame('Foo\\C::bar', $resolved);
+    }
+
+    /**
+     * @throws \LogicException
+     */
     public function testResolvePromotedPropertyCall(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
## Summary
- support resolving method calls on variables assigned from other calls
- add tests covering variable assignments from calls to methods with return types

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68450cf285448328adb19a6be04a03a7