### PR TITLE
Fix catch filtering for callee exceptions

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -316,6 +316,9 @@ class Application
                         if ($calleeKey && $calleeKey !== $funcKey) {
                             $exceptionsFromCallee = GlobalCache::$resolvedThrows[$calleeKey] ?? [];
                             foreach ($exceptionsFromCallee as $ex) {
+                                if ($astUtils->isExceptionCaught($callNode, $ex, $funcNode, $callerNamespace, $callerUseMap)) {
+                                    continue;
+                                }
                                 $throwsFromCallees[] = $ex;
                                 $orig = GlobalCache::$throwOrigins[$calleeKey][$ex] ?? [];
                                 if (!isset($originsFromCallees[$ex])) {

--- a/src/AstUtils.php
+++ b/src/AstUtils.php
@@ -1031,20 +1031,24 @@ class AstUtils
     }
 
     /**
-     * @param \PhpParser\Node\Expr\Throw_ $throwNode
-     * @param string $thrownFqcn
-     * @param \PhpParser\Node $boundaryNode
-     * @param string $currentNamespace
-     * @param mixed[] $useMap
+     * Determine if an exception of the given type would be caught before
+     * propagating outside the provided boundary when thrown from the
+     * given AST node.
+     *
+     * @param Node   $node             Starting point for upward traversal
+     * @param string $thrownFqcn       Fully-qualified class name of the thrown exception
+     * @param Node   $boundaryNode     Typically the enclosing function or method node
+     * @param string|null $currentNamespace Namespace of the starting node
+     * @param mixed[] $useMap          Use statements in effect for the file
      */
     public function isExceptionCaught(
-        $throwNode,
+        Node $node,
         $thrownFqcn,
         $boundaryNode,
         ?string $currentNamespace,
         $useMap
     ): bool {
-        $parent = $throwNode->getAttribute('parent');
+        $parent = $node->getAttribute('parent');
         $currentCatch = null;
         while ($parent && $parent !== $boundaryNode->getAttribute('parent')) {
             if ($parent instanceof Node\Stmt\Catch_) {

--- a/tests/Unit/CallCatchPropagationTest.php
+++ b/tests/Unit/CallCatchPropagationTest.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+use PhpParser\ParserFactory;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
+use PhpParser\NodeFinder;
+use PhpParser\PhpVersion;
+use PHPUnit\Framework\TestCase;
+use HenkPoley\DocBlockDoctor\AstUtils;
+use HenkPoley\DocBlockDoctor\ThrowsGatherer;
+use HenkPoley\DocBlockDoctor\GlobalCache;
+
+class CallCatchPropagationTest extends TestCase
+{
+    /**
+     * @throws \LogicException
+     */
+    public function testExceptionsFromCallAreFilteredByCatch(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace TestNS;
+        class Thrower {
+            public function run(): void {
+                throw new \RuntimeException('fail');
+            }
+        }
+        class Wrapper {
+            public function handle(): void {
+                try {
+                    $t = new Thrower();
+                    $t->run();
+                } catch (\Error $e) {
+                } catch (\Exception $e) {
+                }
+            }
+        }
+        PHP;
+
+        GlobalCache::clear();
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast    = $parser->parse($code) ?: [];
+        $tr1 = new NodeTraverser();
+        $tr1->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $tr1->addVisitor(new ParentConnectingVisitor());
+        $finder = new NodeFinder();
+        $utils  = new AstUtils();
+        $tg     = new ThrowsGatherer($finder, $utils, 'dummy.php');
+        $tr1->addVisitor($tg);
+        $tr1->traverse($ast);
+
+        foreach (array_keys(GlobalCache::$astNodeMap) as $key) {
+            $direct    = GlobalCache::$directThrows[$key] ?? [];
+            $annotated = GlobalCache::$annotatedThrows[$key] ?? [];
+            $combined  = array_values(array_unique(array_merge($direct, $annotated)));
+            sort($combined);
+            GlobalCache::$resolvedThrows[$key] = $combined;
+            if (!isset(GlobalCache::$throwOrigins[$key])) {
+                GlobalCache::$throwOrigins[$key] = [];
+            }
+            foreach ($combined as $ex) {
+                if (!isset(GlobalCache::$throwOrigins[$key][$ex])) {
+                    GlobalCache::$throwOrigins[$key][$ex] = [];
+                }
+            }
+        }
+
+        foreach (GlobalCache::$astNodeMap as $funcKey => $funcNode) {
+            $filePathOfFunc  = GlobalCache::$nodeKeyToFilePath[$funcKey];
+            $callerNamespace = GlobalCache::$fileNamespaces[$filePathOfFunc] ?? '';
+            $callerUseMap    = GlobalCache::$fileUseMaps[$filePathOfFunc] ?? [];
+
+            $baseThrows = GlobalCache::$resolvedThrows[$funcKey] ?? [];
+            $throwsFromCallees = [];
+            if (isset($funcNode->stmts) && is_array($funcNode->stmts)) {
+                $callNodes = array_merge(
+                    $finder->findInstanceOf($funcNode->stmts, PhpParser\Node\Expr\MethodCall::class),
+                    $finder->findInstanceOf($funcNode->stmts, PhpParser\Node\Expr\StaticCall::class),
+                    $finder->findInstanceOf($funcNode->stmts, PhpParser\Node\Expr\FuncCall::class),
+                    $finder->findInstanceOf($funcNode->stmts, PhpParser\Node\Expr\New_::class)
+                );
+                foreach ($callNodes as $callNode) {
+                    if ($utils->isNodeAfterExecutionEndingStmt($callNode, $funcNode)) {
+                        continue;
+                    }
+                    $calleeKey = $utils->getCalleeKey($callNode, $callerNamespace, $callerUseMap, $funcNode);
+                    if ($calleeKey && $calleeKey !== $funcKey) {
+                        foreach (GlobalCache::$resolvedThrows[$calleeKey] ?? [] as $ex) {
+                            if ($utils->isExceptionCaught($callNode, $ex, $funcNode, $callerNamespace, $callerUseMap)) {
+                                continue;
+                            }
+                            $throwsFromCallees[] = $ex;
+                        }
+                    }
+                }
+            }
+            $newThrows = array_values(array_unique(array_merge($baseThrows, $throwsFromCallees)));
+            sort($newThrows);
+            GlobalCache::$resolvedThrows[$funcKey] = $newThrows;
+        }
+
+        $wrapperKey = 'TestNS\\Wrapper::handle';
+        $this->assertArrayHasKey($wrapperKey, GlobalCache::$resolvedThrows);
+        $this->assertSame([], GlobalCache::$resolvedThrows[$wrapperKey]);
+    }
+}

--- a/tests/fixtures/catch-error-exception/CatchErrorException.php
+++ b/tests/fixtures/catch-error-exception/CatchErrorException.php
@@ -1,0 +1,27 @@
+<?php
+namespace Pitfalls\CatchErrorException;
+
+class Thrower {
+    public function doThrow(): void {
+        throw new \RuntimeException('fail');
+    }
+}
+
+class Wrapper {
+    public function handle(): void {
+        try {
+            $t = new Thrower();
+            $t->doThrow();
+        } catch (\Error $e) {
+            // swallow errors
+        } catch (\Exception $e) {
+            // swallow exceptions
+        }
+    }
+}
+
+class Runner {
+    public function run(): void {
+        (new Wrapper())->handle();
+    }
+}

--- a/tests/fixtures/catch-error-exception/expected_results.json
+++ b/tests/fixtures/catch-error-exception/expected_results.json
@@ -1,0 +1,9 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\CatchErrorException\\Thrower::doThrow": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\CatchErrorException\\Wrapper::handle": [],
+    "Pitfalls\\CatchErrorException\\Runner::run": []
+  }
+}


### PR DESCRIPTION
## Summary
- handle catch blocks when propagating exceptions from callees
- generalize `AstUtils::isExceptionCaught()` to work with any node
- add regression fixture and unit test for call caught by `try` block

## Testing
- `vendor/bin/phpunit tests/Unit/CallCatchPropagationTest.php`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6845a4441a3083289bb8b6e4a7f96b8c