### PR TITLE
Fix trait method detection and foreach iteration types

### DIFF
--- a/tests/fixtures/foreach-return-array-annotation/Fixture.php
+++ b/tests/fixtures/foreach-return-array-annotation/Fixture.php
@@ -1,0 +1,32 @@
+<?php
+namespace Pitfalls\ForeachReturnArrayAnnotation;
+
+class Item
+{
+    public function act(): void
+    {
+        throw new \LogicException();
+    }
+}
+
+class Provider
+{
+    /**
+     * @return Item[]
+     */
+    public function getItems(): array
+    {
+        return [new Item()];
+    }
+}
+
+class Consumer
+{
+    public function run(): void
+    {
+        $provider = new Provider();
+        foreach ($provider->getItems() as $item) {
+            $item->act();
+        }
+    }
+}

--- a/tests/fixtures/foreach-return-array-annotation/expected_results.json
+++ b/tests/fixtures/foreach-return-array-annotation/expected_results.json
@@ -1,0 +1,11 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\ForeachReturnArrayAnnotation\\Provider::getItems": [],
+    "Pitfalls\\ForeachReturnArrayAnnotation\\Item::act": [
+      "LogicException"
+    ],
+    "Pitfalls\\ForeachReturnArrayAnnotation\\Consumer::run": [
+      "LogicException"
+    ]
+  }
+}

--- a/tests/fixtures/trait-method-calls/Fixture.php
+++ b/tests/fixtures/trait-method-calls/Fixture.php
@@ -1,0 +1,28 @@
+<?php
+namespace Pitfalls\TraitMethodCalls;
+
+trait WorkerTrait
+{
+    public function run(): void
+    {
+        $this->helper();
+    }
+
+    private function helper(): void
+    {
+        throw new \RuntimeException();
+    }
+}
+
+class Runner
+{
+    use WorkerTrait;
+}
+
+class Caller
+{
+    public function execute(): void
+    {
+        (new Runner())->run();
+    }
+}

--- a/tests/fixtures/trait-method-calls/expected_results.json
+++ b/tests/fixtures/trait-method-calls/expected_results.json
@@ -1,0 +1,13 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\TraitMethodCalls\\WorkerTrait::run": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\TraitMethodCalls\\WorkerTrait::helper": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\TraitMethodCalls\\Caller::execute": [
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- handle array element types from `@return` annotations in foreach loops
- map trait methods to using classes so callee keys resolve
- add regression tests for trait method calls and foreach return array annotations

## Testing
- `vendor/bin/phpunit --stop-on-failure` *(fails: PHPUnit output unavailable due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6845f000ca74832893358cb966c03cea