### PR TITLE
Handle array iteration and trait method aliases

### DIFF
--- a/tests/fixtures/returned-array-iteration/ReturnedArrayIteration.php
+++ b/tests/fixtures/returned-array-iteration/ReturnedArrayIteration.php
@@ -1,0 +1,27 @@
+<?php
+namespace Pitfalls\ReturnedArrayIteration;
+
+class Item {
+    public function work(): void {
+        throw new \RuntimeException();
+    }
+}
+
+class Provider {
+    /**
+     * @return Item[]
+     */
+    public function getItems(): array {
+        return [new Item()];
+    }
+}
+
+class Runner {
+    private Provider $p;
+    public function __construct(Provider $p) { $this->p = $p; }
+    public function run(): void {
+        foreach ($this->p->getItems() as $it) {
+            $it->work();
+        }
+    }
+}

--- a/tests/fixtures/returned-array-iteration/expected_results.json
+++ b/tests/fixtures/returned-array-iteration/expected_results.json
@@ -1,0 +1,11 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\ReturnedArrayIteration\\Provider::getItems": [],
+    "Pitfalls\\ReturnedArrayIteration\\Item::work": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\ReturnedArrayIteration\\Runner::run": [
+      "RuntimeException"
+    ]
+  }
+}

--- a/tests/fixtures/trait-inner-method/TraitInnerMethod.php
+++ b/tests/fixtures/trait-inner-method/TraitInnerMethod.php
@@ -1,0 +1,21 @@
+<?php
+namespace Pitfalls\TraitInnerMethod;
+
+trait HelperTrait {
+    public function bar(): void {
+        throw new \RuntimeException();
+    }
+    public function foo(): void {
+        $this->bar();
+    }
+}
+
+class UseTrait {
+    use HelperTrait;
+}
+
+class Runner {
+    public function run(): void {
+        (new UseTrait())->foo();
+    }
+}

--- a/tests/fixtures/trait-inner-method/expected_results.json
+++ b/tests/fixtures/trait-inner-method/expected_results.json
@@ -1,0 +1,13 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\TraitInnerMethod\\HelperTrait::bar": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\TraitInnerMethod\\HelperTrait::foo": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\TraitInnerMethod\\Runner::run": [
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- support array element type inference from `@return Type[]` via `getArrayReturnItemType`
- resolve method calls on new objects and foreach variables in `AstUtils::getCalleeKey`
- alias trait methods to using classes in `ThrowsGatherer`
- add fixtures for returned array iteration and trait inner method scenarios

## Testing
- `./vendor/bin/phpunit tests/NewIntegration/ThrowsResolutionIntegrationTest.php`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6845fd22a9ac8328838c587bc3b0cd3a