### PR TITLE
Fix vendor path check for Windows

### DIFF
--- a/src/AstUtils.php
+++ b/src/AstUtils.php
@@ -1176,11 +1176,11 @@ class AstUtils
                 /** @var ClassLoader $loader */
                 $loader = $fn[0];
                 $file   = $loader->findFile($fqcn);
-                if (
-                    $file &&
-                    strpos($file, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR) !== false
-                ) {
-                    return true;
+                if ($file) {
+                    $normalized = str_replace(['\\', '/'], '/', $file);
+                    if (strpos($normalized, '/vendor/') !== false) {
+                        return true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- prevent autoloading vendor classes on Windows by normalizing paths

## Testing
- `vendor/bin/phpunit --filter AutoloadingTest`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684a91728c208328a3612877da818d0c