### PR TITLE
Handle trait methods via new object calls

### DIFF
--- a/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
+++ b/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
@@ -129,21 +129,6 @@ class ThrowsResolutionIntegrationTest extends TestCase
                         $calleeKey = null;
                         if (
                             $call instanceof \PhpParser\Node\Expr\MethodCall &&
-                            $call->var instanceof \PhpParser\Node\Expr\New_ &&
-                            $call->var->class instanceof \PhpParser\Node\Name &&
-                            $call->name instanceof \PhpParser\Node\Identifier
-                        ) {
-                            $objClass = $utils->resolveNameNodeToFqcn(
-                                $call->var->class,
-                                $namespace,
-                                $useMap,
-                                false
-                            );
-                            if ($objClass !== '') {
-                                $calleeKey = ltrim($objClass, '\\') . '::' . $call->name->toString();
-                            }
-                        } elseif (
-                            $call instanceof \PhpParser\Node\Expr\MethodCall &&
                             $call->var instanceof \PhpParser\Node\Expr\Variable &&
                             $call->name instanceof \PhpParser\Node\Identifier
                         ) {

--- a/tests/fixtures/trait-inner-method/HelperTrait.php
+++ b/tests/fixtures/trait-inner-method/HelperTrait.php
@@ -1,0 +1,11 @@
+<?php
+namespace Pitfalls\TraitInnerMethod;
+
+trait HelperTrait {
+    public function bar(): void {
+        throw new \RuntimeException();
+    }
+    public function foo(): void {
+        $this->bar();
+    }
+}

--- a/tests/fixtures/trait-inner-method/Runner.php
+++ b/tests/fixtures/trait-inner-method/Runner.php
@@ -1,0 +1,8 @@
+<?php
+namespace Pitfalls\TraitInnerMethod;
+
+class Runner {
+    public function run(): void {
+        (new UseTrait())->foo();
+    }
+}

--- a/tests/fixtures/trait-inner-method/UseTrait.php
+++ b/tests/fixtures/trait-inner-method/UseTrait.php
@@ -1,0 +1,6 @@
+<?php
+namespace Pitfalls\TraitInnerMethod;
+
+class UseTrait {
+    use HelperTrait;
+}

--- a/tests/fixtures/trait-inner-method/expected_results.json
+++ b/tests/fixtures/trait-inner-method/expected_results.json
@@ -1,0 +1,13 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\TraitInnerMethod\\HelperTrait::bar": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\TraitInnerMethod\\HelperTrait::foo": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\TraitInnerMethod\\Runner::run": [
+      "RuntimeException"
+    ]
+  }
+}

--- a/tests/fixtures/trait-overrides-parent/BaseClass.php
+++ b/tests/fixtures/trait-overrides-parent/BaseClass.php
@@ -1,0 +1,8 @@
+<?php
+namespace Pitfalls\TraitOverridesParent;
+
+class BaseClass {
+    public function foo(): void {
+        throw new \LogicException();
+    }
+}

--- a/tests/fixtures/trait-overrides-parent/ChildClass.php
+++ b/tests/fixtures/trait-overrides-parent/ChildClass.php
@@ -1,0 +1,6 @@
+<?php
+namespace Pitfalls\TraitOverridesParent;
+
+class ChildClass extends BaseClass {
+    use SomeTrait;
+}

--- a/tests/fixtures/trait-overrides-parent/ChildOverride.php
+++ b/tests/fixtures/trait-overrides-parent/ChildOverride.php
@@ -1,0 +1,9 @@
+<?php
+namespace Pitfalls\TraitOverridesParent;
+
+class ChildOverride extends BaseClass {
+    use SomeTrait;
+    public function foo(): void {
+        throw new \OverflowException();
+    }
+}

--- a/tests/fixtures/trait-overrides-parent/Runner.php
+++ b/tests/fixtures/trait-overrides-parent/Runner.php
@@ -1,0 +1,8 @@
+<?php
+namespace Pitfalls\TraitOverridesParent;
+
+class Runner {
+    public function run(): void {
+        (new ChildClass())->foo();
+    }
+}

--- a/tests/fixtures/trait-overrides-parent/RunnerOverride.php
+++ b/tests/fixtures/trait-overrides-parent/RunnerOverride.php
@@ -1,0 +1,8 @@
+<?php
+namespace Pitfalls\TraitOverridesParent;
+
+class RunnerOverride {
+    public function run(): void {
+        (new ChildOverride())->foo();
+    }
+}

--- a/tests/fixtures/trait-overrides-parent/SomeTrait.php
+++ b/tests/fixtures/trait-overrides-parent/SomeTrait.php
@@ -1,0 +1,8 @@
+<?php
+namespace Pitfalls\TraitOverridesParent;
+
+trait SomeTrait {
+    public function foo(): void {
+        throw new \RuntimeException();
+    }
+}

--- a/tests/fixtures/trait-overrides-parent/expected_results.json
+++ b/tests/fixtures/trait-overrides-parent/expected_results.json
@@ -1,0 +1,19 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\TraitOverridesParent\\BaseClass::foo": [
+      "LogicException"
+    ],
+    "Pitfalls\\TraitOverridesParent\\SomeTrait::foo": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\TraitOverridesParent\\ChildOverride::foo": [
+      "OverflowException"
+    ],
+    "Pitfalls\\TraitOverridesParent\\Runner::run": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\TraitOverridesParent\\RunnerOverride::run": [
+      "OverflowException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- support resolving method calls on new object expressions
- rely on generic resolution logic in integration tests
- add fixture for trait calls via new objects
- add fixture ensuring trait methods override parent class methods

## Testing
- `./vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_684a991154308328b1596a1fc3a04f4d