### PR TITLE
Fix inline @var comments

### DIFF
--- a/src/AstUtils.php
+++ b/src/AstUtils.php
@@ -434,8 +434,8 @@ class AstUtils
                         continue;
                     }
 
-                    /** @var Node\Stmt\PropertyProperty $propElem */
                     foreach ($stmt->props as $propElem) {
+                        assert($propElem instanceof Node\Stmt\PropertyProperty);
                         if ($propElem->name->toString() === $propertyName) {
                             // Found something like “private Translate $translator;”
                             $docComment = $stmt->getDocComment();
@@ -749,8 +749,8 @@ class AstUtils
             && $callNode->var->class instanceof Class_
             && $callNode->name instanceof Identifier
         ) {
-            /** @var Class_ $anonClass */
             $anonClass = $callNode->var->class;
+            assert($anonClass instanceof Class_);
             if ($anonClass->extends instanceof Name) {
                 $parentFqcn = $this->resolveNameNodeToFqcn(
                     $anonClass->extends,
@@ -1185,8 +1185,8 @@ class AstUtils
         }
         foreach (spl_autoload_functions() as $fn) {
             if (is_array($fn) && $fn[0] instanceof ClassLoader) {
-                /** @var ClassLoader $loader */
                 $loader = $fn[0];
+                assert($loader instanceof ClassLoader);
                 if ($loader->findFile($fqcn)) {
                     return true;
                 }
@@ -1202,8 +1202,8 @@ class AstUtils
     {
         foreach (spl_autoload_functions() as $fn) {
             if (is_array($fn) && $fn[0] instanceof ClassLoader) {
-                /** @var ClassLoader $loader */
                 $loader = $fn[0];
+                assert($loader instanceof ClassLoader);
                 $file   = $loader->findFile($fqcn);
                 if ($file) {
                     $normalized = str_replace(['\\', '/'], '/', $file);

--- a/src/DocBlockUpdater.php
+++ b/src/DocBlockUpdater.php
@@ -109,8 +109,14 @@ class DocBlockUpdater extends NodeVisitorAbstract
             return null;
         }
 
-        /** @var list<class-string> $analyzedThrowsFqcns */
         $analyzedThrowsFqcns = \HenkPoley\DocBlockDoctor\GlobalCache::$resolvedThrows[$nodeKey] ?? [];
+        assert(is_array($analyzedThrowsFqcns));
+        foreach ($analyzedThrowsFqcns as $fqcn) {
+            assert(
+                is_string($fqcn)
+                && AstUtils::classOrInterfaceExistsNoAutoload($fqcn)
+            );
+        }
         // Filter out any classes or interfaces that don’t actually exist
         $analyzedThrowsFqcns = array_filter(
             $analyzedThrowsFqcns,

--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -35,7 +35,8 @@ class GlobalCache
      */
     public static $nodeKeyToFilePath = [];
     /**
-     * @var mixed[]
+     * @psalm-var array<string, list<class-string>> Mapping of method key to
+     * a list of exception FQCNs that are resolved to be thrown by that method.
      */
     public static $resolvedThrows = [];
     /**

--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -387,7 +387,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
             && $n->class instanceof Node\Name);
         $types = [];
         foreach ($matches as $ins) {
-            /** @var Node\Expr\Instanceof_ $ins */
+            assert($ins instanceof Node\Expr\Instanceof_);
             if ($ins->class instanceof Node\Name) {
                 if ($this->instanceofHasInterveningThrow($ins, $varName)) {
                     continue;


### PR DESCRIPTION
## Summary
- replace inline list<class-string> assertion with runtime type checks
- clarify GlobalCache::$resolvedThrows structure with psalm annotation
- assert each resolved throw FQCN exists

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684ab53b42988328a2da554c9a5eb3eb