### PR TITLE
Add tests for static method chain resolution

### DIFF
--- a/tests/fixtures/static-method-chaining-notype/ChainStaticNoType.php
+++ b/tests/fixtures/static-method-chaining-notype/ChainStaticNoType.php
@@ -1,0 +1,21 @@
+<?php
+// tests/fixtures/static-method-chaining-notype/ChainStaticNoType.php
+namespace Pitfalls\StaticMethodChainingNoType;
+
+class Factory {
+    public static function create() {
+        return new Product();
+    }
+}
+
+class Product {
+    public function doWork(): void {
+        throw new \RuntimeException('uh-oh');
+    }
+}
+
+class Caller {
+    public function runAll(): void {
+        Factory::create()->doWork();
+    }
+}

--- a/tests/fixtures/static-method-chaining-notype/expected_results.json
+++ b/tests/fixtures/static-method-chaining-notype/expected_results.json
@@ -1,0 +1,11 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\StaticMethodChainingNoType\\Factory::create": [],
+    "Pitfalls\\StaticMethodChainingNoType\\Product::doWork": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\StaticMethodChainingNoType\\Caller::runAll": [
+      "RuntimeException"
+    ]
+  }
+}

--- a/tests/fixtures/static-method-chaining-nullable/ChainStaticNullable.php
+++ b/tests/fixtures/static-method-chaining-nullable/ChainStaticNullable.php
@@ -1,0 +1,21 @@
+<?php
+// tests/fixtures/static-method-chaining-nullable/ChainStaticNullable.php
+namespace Pitfalls\StaticMethodChainingNullable;
+
+class Factory {
+    public static function maybe(): ?Product {
+        return new Product();
+    }
+}
+
+class Product {
+    public function doWork(): void {
+        throw new \RuntimeException('uh-oh');
+    }
+}
+
+class Caller {
+    public function runAll(): void {
+        Factory::maybe()->doWork();
+    }
+}

--- a/tests/fixtures/static-method-chaining-nullable/expected_results.json
+++ b/tests/fixtures/static-method-chaining-nullable/expected_results.json
@@ -1,0 +1,11 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\StaticMethodChainingNullable\\Factory::maybe": [],
+    "Pitfalls\\StaticMethodChainingNullable\\Product::doWork": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\StaticMethodChainingNullable\\Caller::runAll": [
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add fixtures covering static method chaining with nullable and untyped static methods
- extend `AstUtilsTest` to test `getCalleeKey` for static method chains returning new objects or nullable types

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6857935c3ee88328955ae40d1577eebf