### PR TITLE
Add coverage for promoted property static calls

### DIFF
--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -580,6 +580,104 @@ class AstUtilsTest extends TestCase
     /**
      * @throws \LogicException
      */
+    public function testResolvePromotedPropertyStaticCall(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace PS;
+
+        class Logger { public static function warn(): void {} }
+
+        class S {
+            public function __construct(private Logger $logger) {}
+
+            public function foo(): void {
+                $this->logger::warn();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $foo = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'foo');
+        $this->assertNotNull($foo);
+        $call = $this->finder->findFirstInstanceOf($foo->stmts, Node\Expr\StaticCall::class);
+        $resolved = $this->astUtils->getCalleeKey($call, 'PS', [], $foo);
+        $this->assertSame('PS\\Logger::warn', $resolved);
+    }
+
+    /**
+     * @throws \LogicException
+     */
+    public function testResolveNullablePromotedPropertyStaticCall(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace PSN;
+
+        class Logger { public static function warn(): void {} }
+
+        class S {
+            public function __construct(private ?Logger $logger) {}
+
+            public function foo(): void {
+                $this->logger::warn();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $foo = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'foo');
+        $this->assertNotNull($foo);
+        $call = $this->finder->findFirstInstanceOf($foo->stmts, Node\Expr\StaticCall::class);
+        $resolved = $this->astUtils->getCalleeKey($call, 'PSN', [], $foo);
+        $this->assertSame('PSN\\Logger::warn', $resolved);
+    }
+
+    /**
+     * @throws \LogicException
+     */
     public function testResolveMagicStaticCall(): void
     {
         $code = <<<'PHP'

--- a/tests/fixtures/constructor-property-promotion-static-call-nullable/Template.php
+++ b/tests/fixtures/constructor-property-promotion-static-call-nullable/Template.php
@@ -1,0 +1,16 @@
+<?php
+namespace Pitfalls\ConstructorPropertyPromotionStaticCallNullable;
+
+class Logger {
+    public static function warning(): void {
+        throw new \RuntimeException('fail');
+    }
+}
+
+class Service {
+    public function __construct(private ?Logger $logger) {}
+
+    public function doCall(): void {
+        $this->logger::warning();
+    }
+}

--- a/tests/fixtures/constructor-property-promotion-static-call-nullable/expected_results.json
+++ b/tests/fixtures/constructor-property-promotion-static-call-nullable/expected_results.json
@@ -1,0 +1,10 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\ConstructorPropertyPromotionStaticCallNullable\\Logger::warning": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\ConstructorPropertyPromotionStaticCallNullable\\Service::doCall": [
+      "RuntimeException"
+    ]
+  }
+}

--- a/tests/fixtures/constructor-property-promotion-static-call/Template.php
+++ b/tests/fixtures/constructor-property-promotion-static-call/Template.php
@@ -1,0 +1,16 @@
+<?php
+namespace Pitfalls\ConstructorPropertyPromotionStaticCall;
+
+class Logger {
+    public static function warning(): void {
+        throw new \RuntimeException('fail');
+    }
+}
+
+class Service {
+    public function __construct(private Logger $logger) {}
+
+    public function doCall(): void {
+        $this->logger::warning();
+    }
+}

--- a/tests/fixtures/constructor-property-promotion-static-call/expected_results.json
+++ b/tests/fixtures/constructor-property-promotion-static-call/expected_results.json
@@ -1,0 +1,10 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\ConstructorPropertyPromotionStaticCall\\Logger::warning": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\ConstructorPropertyPromotionStaticCall\\Service::doCall": [
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add fixtures for promoted property static calls
- cover `$this->prop::method()` resolution when property is promoted

## Testing
- `vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6857962b3a1c83289c3fbc9e69c23467