### PR TITLE
Add tests for typed property static calls

### DIFF
--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -678,6 +678,112 @@ class AstUtilsTest extends TestCase
     /**
      * @throws \LogicException
      */
+    public function testResolveTypedPropertyStaticCall(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace PTS;
+
+        class Logger { public static function warn(): void {} }
+
+        class S {
+            private Logger $logger;
+
+            public function __construct() {
+                $this->logger = new Logger();
+            }
+
+            public function foo(): void {
+                $this->logger::warn();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $foo = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'foo');
+        $this->assertNotNull($foo);
+        $call = $this->finder->findFirstInstanceOf($foo->stmts, Node\Expr\StaticCall::class);
+        $resolved = $this->astUtils->getCalleeKey($call, 'PTS', [], $foo);
+        $this->assertSame('PTS\\Logger::warn', $resolved);
+    }
+
+    /**
+     * @throws \LogicException
+     */
+    public function testResolveNullableTypedPropertyStaticCall(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace PTSN;
+
+        class Logger { public static function warn(): void {} }
+
+        class S {
+            private ?Logger $logger;
+
+            public function __construct() {
+                $this->logger = new Logger();
+            }
+
+            public function foo(): void {
+                $this->logger::warn();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $foo = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'foo');
+        $this->assertNotNull($foo);
+        $call = $this->finder->findFirstInstanceOf($foo->stmts, Node\Expr\StaticCall::class);
+        $resolved = $this->astUtils->getCalleeKey($call, 'PTSN', [], $foo);
+        $this->assertSame('PTSN\\Logger::warn', $resolved);
+    }
+
+    /**
+     * @throws \LogicException
+     */
     public function testResolveMagicStaticCall(): void
     {
         $code = <<<'PHP'

--- a/tests/fixtures/property-typed-static-call-nullable/Template.php
+++ b/tests/fixtures/property-typed-static-call-nullable/Template.php
@@ -1,0 +1,20 @@
+<?php
+namespace Pitfalls\PropertyTypedStaticCallNullable;
+
+class Logger {
+    public static function warning(): void {
+        throw new \RuntimeException('fail');
+    }
+}
+
+class Service {
+    private ?Logger $logger;
+
+    public function __construct() {
+        $this->logger = new Logger();
+    }
+
+    public function doCall(): void {
+        $this->logger::warning();
+    }
+}

--- a/tests/fixtures/property-typed-static-call-nullable/expected_results.json
+++ b/tests/fixtures/property-typed-static-call-nullable/expected_results.json
@@ -1,0 +1,10 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\PropertyTypedStaticCallNullable\\Logger::warning": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\PropertyTypedStaticCallNullable\\Service::doCall": [
+      "RuntimeException"
+    ]
+  }
+}

--- a/tests/fixtures/property-typed-static-call/Template.php
+++ b/tests/fixtures/property-typed-static-call/Template.php
@@ -1,0 +1,20 @@
+<?php
+namespace Pitfalls\PropertyTypedStaticCall;
+
+class Logger {
+    public static function warning(): void {
+        throw new \RuntimeException('fail');
+    }
+}
+
+class Service {
+    private Logger $logger;
+
+    public function __construct() {
+        $this->logger = new Logger();
+    }
+
+    public function doCall(): void {
+        $this->logger::warning();
+    }
+}

--- a/tests/fixtures/property-typed-static-call/expected_results.json
+++ b/tests/fixtures/property-typed-static-call/expected_results.json
@@ -1,0 +1,10 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\PropertyTypedStaticCall\\Logger::warning": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\PropertyTypedStaticCall\\Service::doCall": [
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add fixtures for typed property static calls
- test typed property static call resolution in `AstUtils`

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6857984a87248328891d5c1102290a68