### PR TITLE
Fix type hint for getCalleeKey and add regression test

### DIFF
--- a/src/AstUtils.php
+++ b/src/AstUtils.php
@@ -200,7 +200,7 @@ class AstUtils
      * @param \PhpParser\Node\Expr $callNode
      * @param string $callerNamespace
      * @param mixed[] $callerUseMap
-     * @param \PhpParser\Node $callerFuncOrMethodNode
+     * @param \PhpParser\Node\FunctionLike $callerFuncOrMethodNode
      *
      * @throws \LogicException
      */
@@ -208,7 +208,7 @@ class AstUtils
         Node\Expr $callNode,
         string    $callerNamespace,
         array     $callerUseMap,
-        Node      $callerFuncOrMethodNode,
+        Node\FunctionLike $callerFuncOrMethodNode,
         array     &$visited = []
     ): ?string
     {

--- a/tests/Unit/GlobalScopeCallTest.php
+++ b/tests/Unit/GlobalScopeCallTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+use HenkPoley\DocBlockDoctor\AstUtils;
+use HenkPoley\DocBlockDoctor\ThrowsGatherer;
+use HenkPoley\DocBlockDoctor\GlobalCache;
+use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
+use PhpParser\NodeFinder;
+use PHPUnit\Framework\TestCase;
+
+class GlobalScopeCallTest extends TestCase
+{
+    private AstUtils $utils;
+    private NodeFinder $finder;
+
+    protected function setUp(): void
+    {
+        $this->utils = new AstUtils();
+        $this->finder = new NodeFinder();
+        GlobalCache::clear();
+    }
+
+    /**
+     * Ensure that top-level statements do not cause invalid calls to getCalleeKey.
+     *
+     * @throws \LogicException
+     */
+    public function testTopLevelCallIsIgnored(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        class Foo { public function bar(): void {} }
+        $f = new Foo();
+        $f->bar();
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code) ?: [];
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new ThrowsGatherer($this->finder, $this->utils, 'dummy'));
+        $traverser->traverse($ast);
+
+        // Only the method inside Foo should be registered, the top-level call should be ignored
+        $this->assertArrayHasKey('Foo::bar', GlobalCache::$astNodeMap);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `getCalleeKey` expects `Node\FunctionLike`
- add test covering top-level call scenario

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68579cbb38088328bf35f3d7fce8f373