### PR TITLE
Add coverage for nullable return assignments

### DIFF
--- a/tests/fixtures/returned-object-assignment-nullable/ReturnAssignNullableFixture.php
+++ b/tests/fixtures/returned-object-assignment-nullable/ReturnAssignNullableFixture.php
@@ -1,0 +1,25 @@
+<?php
+// tests/fixtures/returned-object-assignment-nullable/ReturnAssignNullableFixture.php
+namespace Pitfalls\ReturnedObjectAssignmentNullable;
+
+class Provider {
+    public function maybe(): ?Handler {
+        return new Handler();
+    }
+}
+
+class Handler {
+    /**
+     * @throws \DomainException
+     */
+    public function handle(): void {
+        throw new \DomainException('oops');
+    }
+}
+
+class Runner {
+    public function run(): void {
+        $h = (new Provider())->maybe();
+        $h->handle();
+    }
+}

--- a/tests/fixtures/returned-object-assignment-nullable/expected_results.json
+++ b/tests/fixtures/returned-object-assignment-nullable/expected_results.json
@@ -1,0 +1,11 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\ReturnedObjectAssignmentNullable\\Provider::maybe": [],
+    "Pitfalls\\ReturnedObjectAssignmentNullable\\Handler::handle": [
+      "DomainException"
+    ],
+    "Pitfalls\\ReturnedObjectAssignmentNullable\\Runner::run": [
+      "DomainException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add fixture for nullable return on assigned objects
- test resolving methods from nullable assignments

## Testing
- `./vendor/bin/phpunit --filter AstUtilsTest --stop-on-failure`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68579ec7b4b0832890b6c88af76a121a