### PR TITLE
Add coverage for new object return chains

### DIFF
--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -1323,4 +1323,68 @@ class AstUtilsTest extends TestCase
         $resolved = $this->astUtils->getCalleeKey($targetCall, 'MR', [], $run);
         $this->assertSame('MR\\A::act', $resolved);
     }
+
+    /**
+     * @throws \LogicException
+     */
+    public function testResolveAssignedFromCallMultipleReturns(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace MRVar;
+
+        class Factory {
+            public function create(bool $flag) {
+                if ($flag) {
+                    return new A();
+                }
+                return new B();
+            }
+        }
+
+        class A { public function act(): void {} }
+        class B { public function act(): void {} }
+
+        class User {
+            private Factory $f;
+            public function __construct(Factory $f) { $this->f = $f; }
+            public function run(bool $flag): void {
+                $p = $this->f->create($flag);
+                $p->act();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $run = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'run');
+        $this->assertNotNull($run);
+        $call = $this->finder->findFirst(
+            $run->stmts,
+            fn(Node $n) => $n instanceof Node\Expr\MethodCall && $n->name instanceof Node\Identifier && $n->name->toString() === 'act'
+        );
+        $this->assertNotNull($call);
+        $resolved = $this->astUtils->getCalleeKey($call, 'MRVar', [], $run);
+        $this->assertSame('MRVar\\A::act', $resolved);
+    }
 }

--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -1256,4 +1256,71 @@ class AstUtilsTest extends TestCase
         $resolved = $this->astUtils->getCalleeKey($targetCall, 'S\\NoTypeChain', [], $run);
         $this->assertSame('S\\NoTypeChain\\Product::work', $resolved);
     }
+
+    /**
+     * @throws \LogicException
+     */
+    public function testResolveMethodChainMultipleReturns(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace MR;
+
+        class Factory {
+            public function create(bool $flag) {
+                if ($flag) {
+                    return new A();
+                }
+                return new B();
+            }
+        }
+
+        class A { public function act(): void {} }
+        class B { public function act(): void {} }
+
+        class Caller {
+            private Factory $f;
+            public function __construct(Factory $f) { $this->f = $f; }
+            public function run(bool $flag): void {
+                $this->f->create($flag)->act();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $run = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'run');
+        $this->assertNotNull($run);
+        $calls = $this->finder->findInstanceOf($run->stmts, Node\Expr\MethodCall::class);
+        $targetCall = null;
+        foreach ($calls as $c) {
+            if ($c->name instanceof Node\Identifier && $c->name->toString() === 'act') {
+                $targetCall = $c;
+                break;
+            }
+        }
+        $this->assertNotNull($targetCall);
+        $resolved = $this->astUtils->getCalleeKey($targetCall, 'MR', [], $run);
+        $this->assertSame('MR\\A::act', $resolved);
+    }
 }

--- a/tests/fixtures/method-chaining-multiple-returns/MultiReturnChain.php
+++ b/tests/fixtures/method-chaining-multiple-returns/MultiReturnChain.php
@@ -1,0 +1,36 @@
+<?php
+// tests/fixtures/method-chaining-multiple-returns/MultiReturnChain.php
+namespace Pitfalls\MethodChainingMultipleReturns;
+
+class Factory {
+    public function create(bool $flag) {
+        if ($flag) {
+            return new ProductA();
+        }
+        return new ProductB();
+    }
+}
+
+class ProductA {
+    public function doWork(): void {
+        throw new \RuntimeException('A');
+    }
+}
+
+class ProductB {
+    public function doWork(): void {
+        throw new \InvalidArgumentException('B');
+    }
+}
+
+class Caller {
+    private Factory $f;
+
+    public function __construct(Factory $f) {
+        $this->f = $f;
+    }
+
+    public function run(bool $flag): void {
+        $this->f->create($flag)->doWork();
+    }
+}

--- a/tests/fixtures/method-chaining-multiple-returns/expected_results.json
+++ b/tests/fixtures/method-chaining-multiple-returns/expected_results.json
@@ -1,0 +1,14 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\MethodChainingMultipleReturns\\Factory::create": [],
+    "Pitfalls\\MethodChainingMultipleReturns\\ProductA::doWork": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\MethodChainingMultipleReturns\\ProductB::doWork": [
+      "InvalidArgumentException"
+    ],
+    "Pitfalls\\MethodChainingMultipleReturns\\Caller::run": [
+      "RuntimeException"
+    ]
+  }
+}

--- a/tests/fixtures/returned-object-assignment-multiple-returns/ReturnAssignMultiple.php
+++ b/tests/fixtures/returned-object-assignment-multiple-returns/ReturnAssignMultiple.php
@@ -1,0 +1,33 @@
+<?php
+// tests/fixtures/returned-object-assignment-multiple-returns/ReturnAssignMultiple.php
+namespace Pitfalls\ReturnAssignMultiple;
+
+class Factory {
+    public function create(bool $flag) {
+        if ($flag) {
+            return new ProductA();
+        }
+        return new ProductB();
+    }
+}
+
+class ProductA {
+    public function work(): void {
+        throw new \RuntimeException('A');
+    }
+}
+
+class ProductB {
+    public function work(): void {
+        throw new \InvalidArgumentException('B');
+    }
+}
+
+class Runner {
+    private Factory $f;
+    public function __construct(Factory $f) { $this->f = $f; }
+    public function run(bool $flag): void {
+        $p = $this->f->create($flag);
+        $p->work();
+    }
+}

--- a/tests/fixtures/returned-object-assignment-multiple-returns/expected_results.json
+++ b/tests/fixtures/returned-object-assignment-multiple-returns/expected_results.json
@@ -1,0 +1,14 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\ReturnAssignMultiple\\Factory::create": [],
+    "Pitfalls\\ReturnAssignMultiple\\ProductA::work": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\ReturnAssignMultiple\\ProductB::work": [
+      "InvalidArgumentException"
+    ],
+    "Pitfalls\\ReturnAssignMultiple\\Runner::run": [
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add fixture `method-chaining-multiple-returns`
- add PHPUnit test for chaining when method has multiple `return new` statements

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6857a0ecf56c832883f450b9230f8b2c