### PR TITLE
Add test for reflection-based method resolution

### DIFF
--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -1387,4 +1387,50 @@ class AstUtilsTest extends TestCase
         $resolved = $this->astUtils->getCalleeKey($call, 'MRVar', [], $run);
         $this->assertSame('MRVar\\A::act', $resolved);
     }
+
+    /**
+     * @throws \LogicException
+     */
+    public function testResolveExistingClassStaticMethodViaReflection(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace TR;
+
+        class Example {
+            public function run(): void {
+                \DateTime::createfromformat('Y-m-d', '2021-01-01');
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $run = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'run');
+        $this->assertNotNull($run);
+        $call = $this->finder->findFirstInstanceOf($run->stmts, Node\Expr\StaticCall::class);
+        $this->assertNotNull($call);
+        $resolved = $this->astUtils->getCalleeKey($call, 'TR', [], $run);
+        $this->assertSame('DateTime::createFromFormat', $resolved);
+    }
 }

--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -1,6 +1,18 @@
 <?php
 declare(strict_types=1);
 
+namespace HenkPoley\DocBlockDoctor;
+
+function class_exists(string $class, bool $autoload = true): bool
+{
+    $overrides = $GLOBALS['__override_class_exists'] ?? [];
+    if (array_key_exists($class, $overrides)) {
+        return $overrides[$class];
+    }
+
+    return \class_exists($class, $autoload);
+}
+
 namespace HenkPoley\DocBlockDoctor\Tests\Unit;
 
 use HenkPoley\DocBlockDoctor\AstUtils;
@@ -1432,5 +1444,101 @@ class AstUtilsTest extends TestCase
         $this->assertNotNull($call);
         $resolved = $this->astUtils->getCalleeKey($call, 'TR', [], $run);
         $this->assertSame('DateTime::createFromFormat', $resolved);
+    }
+
+    /**
+     * @throws \LogicException
+     */
+    public function testResolveExistingClassMissingMethodFallsBack(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace ST;
+
+        class Example {
+            public function run(): void {
+                \DateTime::nosuchmethod();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $run = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'run');
+        $this->assertNotNull($run);
+        $call = $this->finder->findFirstInstanceOf($run->stmts, Node\Expr\StaticCall::class);
+        $this->assertNotNull($call);
+        $resolved = $this->astUtils->getCalleeKey($call, 'ST', [], $run);
+        $this->assertSame('DateTime::nosuchmethod', $resolved);
+    }
+
+    /**
+     * @throws \LogicException
+     */
+    public function testReflectionExceptionDuringClassCheckIsCaught(): void
+    {
+        $GLOBALS['__override_class_exists']['GhostClass'] = true;
+
+        $code = <<<'PHP'
+        <?php
+        namespace RC;
+
+        class Example {
+            public function run(): void {
+                \GhostClass::doIt();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        $run = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'run');
+        $this->assertNotNull($run);
+        $call = $this->finder->findFirstInstanceOf($run->stmts, Node\Expr\StaticCall::class);
+        $this->assertNotNull($call);
+        $resolved = $this->astUtils->getCalleeKey($call, 'RC', [], $run);
+        $this->assertSame('GhostClass::doIt', $resolved);
+
+        unset($GLOBALS['__override_class_exists']['GhostClass']);
     }
 }


### PR DESCRIPTION
## Summary
- add new PHPUnit test to exercise `getCalleeKey` when a class exists but is not in `GlobalCache`

## Testing
- `vendor/bin/phpunit tests/Unit/AstUtilsTest.php`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6857a684dd1c8328ae64b0a114b1dd32