### PR TITLE
Add test for inherited static call case

### DIFF
--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -1495,6 +1495,58 @@ class AstUtilsTest extends TestCase
     /**
      * @throws \LogicException
      */
+    public function testResolveInheritedStaticCallUsesDeclaringClass(): void
+    {
+        eval('namespace SCI; class ParentClass { public static function DoIt() {} }');
+
+        $code = <<<'PHP'
+        <?php
+        namespace SCI;
+
+        class Child extends ParentClass {}
+
+        class Example {
+            public function run(): void {
+                Child::doit();
+            }
+        }
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->addVisitor(new class($this->astUtils) extends \PhpParser\NodeVisitorAbstract {
+            private AstUtils $u; private string $ns = '';
+            public function __construct(AstUtils $u) { $this->u = $u; }
+            public function beforeTraverse(array $nodes) {
+                $finder = new NodeFinder();
+                $nsNode = $finder->findFirstInstanceOf($nodes, Node\Stmt\Namespace_::class);
+                if ($nsNode && $nsNode->name) { $this->ns = $nsNode->name->toString(); }
+                return null;
+            }
+            public function enterNode(Node $n) {
+                if ($n instanceof Node\Stmt\ClassMethod) {
+                    $key = $this->u->getNodeKey($n, $this->ns); GlobalCache::$astNodeMap[$key] = $n; GlobalCache::$nodeKeyToFilePath[$key] = 'dummy';
+                }
+            }
+        });
+        $traverser->traverse($ast);
+
+        GlobalCache::$classParents['SCI\\Child'] = 'SCI\\ParentClass';
+
+        $run = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'run');
+        $this->assertNotNull($run);
+        $call = $this->finder->findFirstInstanceOf($run->stmts, Node\Expr\StaticCall::class);
+        $this->assertNotNull($call);
+        $resolved = $this->astUtils->getCalleeKey($call, 'SCI', [], $run);
+        $this->assertSame('SCI\\ParentClass::DoIt', $resolved);
+    }
+
+    /**
+     * @throws \LogicException
+     */
     public function testReflectionExceptionDuringClassCheckIsCaught(): void
     {
         $GLOBALS['__override_class_exists']['GhostClass'] = true;


### PR DESCRIPTION
## Summary
- increase coverage of `AstUtils::getCalleeKey` when resolving a static call
  to a method inherited from a parent class

## Testing
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6857aab43a9483288a33484ed0d94cd5