### PR TITLE
Refactor Application processing steps

### DIFF
--- a/src/ApplicationOptions.php
+++ b/src/ApplicationOptions.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace HenkPoley\DocBlockDoctor;
+
+/**
+ * Value object holding command line options for the application.
+ */
+class ApplicationOptions
+{
+    public bool $verbose = false;
+    public bool $traceOrigins = false;
+    public bool $traceCallSites = false;
+    public bool $ignoreAnnotatedThrows = false;
+    public string $rootDir = '';
+    /** @var string[]|null */
+    public ?array $readDirs = null;
+    /** @var string[]|null */
+    public ?array $writeDirs = null;
+}


### PR DESCRIPTION
## Summary
- introduce `ApplicationOptions` value object
- refactor `Application` to parse CLI options into `ApplicationOptions`
- move directory resolution, file collection and processing phases into helper methods
- keep `run()` as a thin orchestrator

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6857f2f7c8bc83289e4607d6c4a0a942