### PR TITLE
Add coverage for CLI option parsing and Application::run

### DIFF
--- a/tests/NewIntegration/ApplicationRunIntegrationTest.php
+++ b/tests/NewIntegration/ApplicationRunIntegrationTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\Tests\NewIntegration;
+
+use HenkPoley\DocBlockDoctor\Application;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationRunIntegrationTest extends TestCase
+{
+    /**
+     * @throws \LogicException
+     */
+    public function testRunModifiesFilesAndOutputsSummary(): void
+    {
+        $tmpRoot = sys_get_temp_dir() . '/docblockdoctor-run-' . uniqid();
+        mkdir($tmpRoot);
+        copy(__DIR__ . '/../fixtures/single-line-method-docblock/InlineDocblock.php', $tmpRoot . '/InlineDocblock.php');
+        $expected = file_get_contents(__DIR__ . '/../fixtures/single-line-method-docblock/expected_rewritten.php');
+
+        $app = new Application();
+        ob_start();
+        $app->run(['doc-block-doctor', '--verbose', $tmpRoot]);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('=== Summary ===', $output);
+        $this->assertStringContainsString('Files read (1):', $output);
+        $this->assertStringContainsString('Files fixed (1):', $output);
+
+        $result = file_get_contents($tmpRoot . '/InlineDocblock.php');
+        $this->assertSame($expected, $result);
+
+        unlink($tmpRoot . '/InlineDocblock.php');
+        rmdir($tmpRoot);
+    }
+}

--- a/tests/Unit/ApplicationParseOptionsTest.php
+++ b/tests/Unit/ApplicationParseOptionsTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\Tests\Unit;
+
+use HenkPoley\DocBlockDoctor\Application;
+use HenkPoley\DocBlockDoctor\ApplicationOptions;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationParseOptionsTest extends TestCase
+{
+    /**
+     * Helper to invoke the private parseOptions method.
+     *
+     * @param string[] $args
+     */
+    private function parse(array $args): ApplicationOptions
+    {
+        $app = new Application();
+        $ref = new \ReflectionMethod(Application::class, 'parseOptions');
+        $ref->setAccessible(true);
+        /** @var ApplicationOptions $opt */
+        $opt = $ref->invoke($app, $args);
+        return $opt;
+    }
+
+    public function testDefaultsWhenNoPathProvided(): void
+    {
+        $orig = getcwd();
+        $tmp = sys_get_temp_dir() . '/docblockdoctor-' . uniqid();
+        mkdir($tmp);
+        chdir($tmp);
+        $opt = $this->parse(['doc-block-doctor']);
+        chdir($orig);
+
+        $this->assertSame($tmp, $opt->rootDir);
+        $this->assertFalse($opt->verbose);
+        $this->assertNull($opt->readDirs);
+        $this->assertNull($opt->writeDirs);
+    }
+
+    public function testFlagsAndDirectoriesParsed(): void
+    {
+        $opt = $this->parse([
+            'doc-block-doctor',
+            '-v',
+            '--trace-throw-origins',
+            '--trace-throw-call-sites',
+            '--ignore-annotated-throws',
+            '--read-dirs=src,tests',
+            '--write-dirs=src,generated',
+            '/my/project/',
+        ]);
+
+        $this->assertTrue($opt->verbose);
+        $this->assertTrue($opt->traceOrigins);
+        $this->assertTrue($opt->traceCallSites);
+        $this->assertTrue($opt->ignoreAnnotatedThrows);
+        $this->assertSame('/my/project', $opt->rootDir);
+        $this->assertSame(['src', 'tests'], $opt->readDirs);
+        $this->assertSame(['src', 'generated'], $opt->writeDirs);
+    }
+}

--- a/tests/Unit/ApplicationParseOptionsTest.php
+++ b/tests/Unit/ApplicationParseOptionsTest.php
@@ -33,10 +33,12 @@ class ApplicationParseOptionsTest extends TestCase
         $opt = $this->parse(['doc-block-doctor']);
         chdir($orig);
 
-        $this->assertSame($tmp, $opt->rootDir);
+        $this->assertSame(realpath($tmp), $opt->rootDir);
         $this->assertFalse($opt->verbose);
         $this->assertNull($opt->readDirs);
         $this->assertNull($opt->writeDirs);
+
+        rmdir($tmp);
     }
 
     public function testFlagsAndDirectoriesParsed(): void


### PR DESCRIPTION
## Summary
- test parsing command line options
- integration test for Application::run including verbose summary

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6857f86728948328984a5f6f2ce02c1b