### PR TITLE
Add FileSystem and AstParser interfaces

### DIFF
--- a/src/AstParser.php
+++ b/src/AstParser.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace HenkPoley\DocBlockDoctor;
+
+use PhpParser\Error;
+use PhpParser\Node;
+use PhpParser\NodeVisitor;
+
+interface AstParser
+{
+    /**
+     * @return Node[]|null
+     * @throws Error
+     */
+    public function parse(string $code): ?array;
+
+    /**
+     * @param Node[] $ast
+     * @param NodeVisitor[] $visitors
+     */
+    public function traverse(array $ast, array $visitors): void;
+}

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace HenkPoley\DocBlockDoctor;
+
+interface FileSystem
+{
+    public function getContents(string $path): string|false;
+    public function putContents(string $path, string $contents): bool;
+    public function isFile(string $path): bool;
+    public function isDir(string $path): bool;
+    public function realPath(string $path): string|false;
+    public function getCurrentWorkingDirectory(): string|false;
+}

--- a/src/NativeFileSystem.php
+++ b/src/NativeFileSystem.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace HenkPoley\DocBlockDoctor;
+
+class NativeFileSystem implements FileSystem
+{
+    public function getContents(string $path): string|false
+    {
+        return @file_get_contents($path);
+    }
+
+    public function putContents(string $path, string $contents): bool
+    {
+        return file_put_contents($path, $contents) !== false;
+    }
+
+    public function isFile(string $path): bool
+    {
+        return is_file($path);
+    }
+
+    public function isDir(string $path): bool
+    {
+        return is_dir($path);
+    }
+
+    public function realPath(string $path): string|false
+    {
+        return realpath($path);
+    }
+
+    public function getCurrentWorkingDirectory(): string|false
+    {
+        return getcwd();
+    }
+}

--- a/src/PhpParserAstParser.php
+++ b/src/PhpParserAstParser.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace HenkPoley\DocBlockDoctor;
+
+use PhpParser\Error;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
+
+class PhpParserAstParser implements AstParser
+{
+    private Parser $parser;
+
+    public function __construct()
+    {
+        $this->parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 1));
+    }
+
+    /**
+     * @return Node[]|null
+     * @throws Error
+     */
+    public function parse(string $code): ?array
+    {
+        return $this->parser->parse($code);
+    }
+
+    /**
+     * @param Node[] $ast
+     * @param NodeVisitor[] $visitors
+     */
+    public function traverse(array $ast, array $visitors): void
+    {
+        $traverser = new NodeTraverser();
+        foreach ($visitors as $v) {
+            $traverser->addVisitor($v);
+        }
+        $traverser->traverse($ast);
+    }
+}

--- a/tests/Unit/ApplicationDependencyInjectionTest.php
+++ b/tests/Unit/ApplicationDependencyInjectionTest.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\Tests\Unit;
+
+use HenkPoley\DocBlockDoctor\Application;
+use HenkPoley\DocBlockDoctor\ApplicationOptions;
+use HenkPoley\DocBlockDoctor\AstParser;
+use HenkPoley\DocBlockDoctor\FileSystem;
+use HenkPoley\DocBlockDoctor\AstUtils;
+use PhpParser\Error;
+use PhpParser\NodeFinder;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationDependencyInjectionTest extends TestCase
+{
+    public function testProcessFilesPass1HandlesParseError(): void
+    {
+        $fs = new class implements FileSystem {
+            public function getContents(string $path): string|false { return '<?php echo "hi";'; }
+            public function putContents(string $path, string $contents): bool { return true; }
+            public function isFile(string $path): bool { return true; }
+            public function isDir(string $path): bool { return true; }
+            public function realPath(string $path): string|false { return $path; }
+            public function getCurrentWorkingDirectory(): string|false { return '/tmp'; }
+        };
+        $parser = new class implements AstParser {
+            public function parse(string $code): ?array { throw new Error('fail'); }
+            public function traverse(array $ast, array $visitors): void {}
+        };
+
+        $app = new Application($fs, $parser);
+        $ref = new \ReflectionMethod(Application::class, 'processFilesPass1');
+        $ref->setAccessible(true);
+        $nodeFinder = new NodeFinder();
+        $astUtils   = new AstUtils();
+        $opt = new ApplicationOptions();
+        ob_start();
+        $ref->invoke($app, ['/tmp/test.php'], $nodeFinder, $astUtils, $opt);
+        $output = ob_get_clean();
+        $this->assertStringContainsString('Parse error (Pass 1)', $output);
+    }
+
+    public function testProcessFilesPass1HandlesReadError(): void
+    {
+        $fs = new class implements FileSystem {
+            public function getContents(string $path): string|false { return false; }
+            public function putContents(string $path, string $contents): bool { return true; }
+            public function isFile(string $path): bool { return true; }
+            public function isDir(string $path): bool { return true; }
+            public function realPath(string $path): string|false { return $path; }
+            public function getCurrentWorkingDirectory(): string|false { return '/tmp'; }
+        };
+        $called = false;
+        $parser = new class($called) implements AstParser {
+            public bool $called = false;
+            public function __construct(&$flag){$this->called =& $flag;}
+            public function parse(string $code): ?array { $this->called = true; return []; }
+            public function traverse(array $ast, array $visitors): void {}
+        };
+
+        $app = new Application($fs, $parser);
+        $ref = new \ReflectionMethod(Application::class, 'processFilesPass1');
+        $ref->setAccessible(true);
+        $nodeFinder = new NodeFinder();
+        $astUtils   = new AstUtils();
+        $opt = new ApplicationOptions();
+        ob_start();
+        $ref->invoke($app, ['/tmp/test.php'], $nodeFinder, $astUtils, $opt);
+        $output = ob_get_clean();
+        $this->assertStringContainsString('Cannot read file', $output);
+        $this->assertFalse($parser->called, 'Parser should not be called when file read fails');
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `FileSystem` and `AstParser` abstractions with default implementations
- inject these services into `Application`
- refactor `Application` to use injected services
- add unit tests showing dependency injection behavior

## Testing
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6857ff4f41388328944b30aa9487d39e