### PR TITLE
Add GlobalCache utilities and clear cache on run start

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -45,6 +45,8 @@ class Application
             }
         }
 
+        GlobalCache::clear();
+
         $opt = $this->parseOptions($argv);
         $this->resolveDirectories($opt);
 

--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -71,4 +71,36 @@ class GlobalCache
         self::$classParents = [];
         self::$classTraits = [];
     }
+
+    /**
+     * @return mixed[]
+     */
+    public static function getResolvedThrowsForKey(string $key): array
+    {
+        return self::$resolvedThrows[$key] ?? [];
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public static function getThrowOriginsForKey(string $key): array
+    {
+        return self::$throwOrigins[$key] ?? [];
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    public static function getAllResolvedThrows(): array
+    {
+        return self::$resolvedThrows;
+    }
+
+    /**
+     * @return array<string, array<string, string[]>>
+     */
+    public static function getAllThrowOrigins(): array
+    {
+        return self::$throwOrigins;
+    }
 }

--- a/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
+++ b/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
@@ -162,9 +162,10 @@ class ThrowsResolutionIntegrationTest extends TestCase
         $expectedFile = $fixtureRoot . '/expected_results.json';
         $this->assertFileExists($expectedFile);
         $expectedData = json_decode(file_get_contents($expectedFile), true, 512, JSON_THROW_ON_ERROR);
+        $allResolved = GlobalCache::getAllResolvedThrows();
         foreach ($expectedData['fullyQualifiedMethodKeys'] as $methodKey => $throws) {
-            $this->assertArrayHasKey($methodKey, GlobalCache::$resolvedThrows, $methodKey . ' missing');
-            $this->assertEqualsCanonicalizing($throws, GlobalCache::$resolvedThrows[$methodKey], $methodKey);
+            $this->assertArrayHasKey($methodKey, $allResolved, $methodKey . ' missing');
+            $this->assertEqualsCanonicalizing($throws, GlobalCache::getResolvedThrowsForKey($methodKey), $methodKey);
         }
     }
 

--- a/tests/Unit/CallCatchPropagationTest.php
+++ b/tests/Unit/CallCatchPropagationTest.php
@@ -102,7 +102,8 @@ class CallCatchPropagationTest extends TestCase
         }
 
         $wrapperKey = 'TestNS\\Wrapper::handle';
-        $this->assertArrayHasKey($wrapperKey, GlobalCache::$resolvedThrows);
-        $this->assertSame([], GlobalCache::$resolvedThrows[$wrapperKey]);
+        $all = GlobalCache::getAllResolvedThrows();
+        $this->assertArrayHasKey($wrapperKey, $all);
+        $this->assertSame([], GlobalCache::getResolvedThrowsForKey($wrapperKey));
     }
 }

--- a/tests/Unit/ThrowsGathererTest.php
+++ b/tests/Unit/ThrowsGathererTest.php
@@ -169,9 +169,10 @@ class ThrowsGathererTest extends TestCase
             ['RuntimeException', 'Throwable'],
             GlobalCache::$directThrows[$key]
         );
+        $origins = GlobalCache::getThrowOriginsForKey($key);
         $this->assertSame(
             ['T\\C::foo <- dummyPath:11'],
-            GlobalCache::$throwOrigins[$key]['RuntimeException'] ?? null
+            $origins['RuntimeException'] ?? null
         );
     }
 


### PR DESCRIPTION
## Summary
- add helper accessors in `GlobalCache`
- clear the static cache when `Application::run()` begins

## Testing
- `vendor/bin/phpunit -c phpunit.xml --stop-on-failure --colors=never`
- `vendor/bin/psalm --no-progress` *(fails: 100 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685807db9e0c8328b7d0eee9b89afab6