### PR TITLE
Add application run integration tests with new fixtures

### DIFF
--- a/tests/NewIntegration/ApplicationRunFixtureProjectsTest.php
+++ b/tests/NewIntegration/ApplicationRunFixtureProjectsTest.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\Tests\NewIntegration;
+
+use HenkPoley\DocBlockDoctor\Application;
+use HenkPoley\DocBlockDoctor\FileSystem;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationRunFixtureProjectsTest extends TestCase
+{
+    /**
+     * @dataProvider projectProvider
+     * @throws \LogicException
+     */
+    public function testRunRewritesFixtures(string $scenario, array $files): void
+    {
+        $srcDir = __DIR__ . '/../fixtures/' . $scenario;
+        $tmpRoot = sys_get_temp_dir() . '/docblockdoctor-run-' . uniqid();
+        mkdir($tmpRoot);
+        foreach ($files as $file) {
+            copy($srcDir . '/' . $file, $tmpRoot . '/' . $file);
+        }
+
+        $app = new Application();
+        ob_start();
+        $app->run(['doc-block-doctor', '--verbose', $tmpRoot]);
+        $output = ob_get_clean();
+        $this->assertStringContainsString('=== Summary ===', $output);
+
+        foreach ($files as $file) {
+            $expected = file_get_contents($srcDir . '/expected_' . $file);
+            $this->assertNotFalse($expected);
+            $actual = file_get_contents($tmpRoot . '/' . $file);
+            $this->assertSame($expected, $actual, $file . ' mismatch');
+            unlink($tmpRoot . '/' . $file);
+        }
+        rmdir($tmpRoot);
+    }
+
+    public static function projectProvider(): array
+    {
+        return [
+            ['app-run-basic', ['Foo.php', 'Bar.php']],
+        ];
+    }
+
+    public function testRunHandlesMissingFileGracefully(): void
+    {
+        $srcDir = __DIR__ . '/../fixtures/app-run-basic';
+        $tmpRoot = sys_get_temp_dir() . '/docblockdoctor-run-' . uniqid();
+        mkdir($tmpRoot);
+        copy($srcDir . '/Foo.php', $tmpRoot . '/Foo.php');
+
+        $fs = new class($tmpRoot . '/Foo.php') implements FileSystem {
+            private string $failPath;
+            public function __construct(string $failPath) { $this->failPath = $failPath; }
+            public function getContents(string $path): string|false { return $path === $this->failPath ? false : @file_get_contents($path); }
+            public function putContents(string $path, string $contents): bool { return file_put_contents($path, $contents) !== false; }
+            public function isFile(string $path): bool { return is_file($path); }
+            public function isDir(string $path): bool { return is_dir($path); }
+            public function realPath(string $path): string|false { return realpath($path); }
+            public function getCurrentWorkingDirectory(): string|false { return getcwd(); }
+        };
+
+        $app = new Application($fs);
+        ob_start();
+        $app->run(['doc-block-doctor', '--verbose', $tmpRoot]);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Cannot read file', $output);
+        $result = file_get_contents($tmpRoot . '/Foo.php');
+        $original = file_get_contents($srcDir . '/Foo.php');
+        $this->assertSame($original, $result);
+
+        unlink($tmpRoot . '/Foo.php');
+        rmdir($tmpRoot);
+    }
+
+    public function testRunHandlesWriteError(): void
+    {
+        $srcDir = __DIR__ . '/../fixtures/app-run-basic';
+        $tmpRoot = sys_get_temp_dir() . '/docblockdoctor-run-' . uniqid();
+        mkdir($tmpRoot);
+        copy($srcDir . '/Foo.php', $tmpRoot . '/Foo.php');
+
+        $fs = new class($tmpRoot . '/Foo.php') implements FileSystem {
+            private string $failPath;
+            public function __construct(string $failPath) { $this->failPath = $failPath; }
+            public function getContents(string $path): string|false { return @file_get_contents($path); }
+            public function putContents(string $path, string $contents): bool { return $path === $this->failPath ? false : file_put_contents($path, $contents) !== false; }
+            public function isFile(string $path): bool { return is_file($path); }
+            public function isDir(string $path): bool { return is_dir($path); }
+            public function realPath(string $path): string|false { return realpath($path); }
+            public function getCurrentWorkingDirectory(): string|false { return getcwd(); }
+        };
+
+        $app = new Application($fs);
+        ob_start();
+        $app->run(['doc-block-doctor', '--verbose', $tmpRoot]);
+        ob_get_clean();
+
+        $result = file_get_contents($tmpRoot . '/Foo.php');
+        $original = file_get_contents($srcDir . '/Foo.php');
+        $this->assertSame($original, $result);
+
+        unlink($tmpRoot . '/Foo.php');
+        rmdir($tmpRoot);
+    }
+
+    public function testRunHandlesMalformedPhp(): void
+    {
+        $srcDir = __DIR__ . '/../fixtures/app-run-malformed';
+        $tmpRoot = sys_get_temp_dir() . '/docblockdoctor-run-' . uniqid();
+        mkdir($tmpRoot);
+        copy($srcDir . '/Broken.php', $tmpRoot . '/Broken.php');
+
+        $app = new Application();
+        ob_start();
+        $app->run(['doc-block-doctor', '--verbose', $tmpRoot]);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Parse error (Pass 1)', $output);
+        $result = file_get_contents($tmpRoot . '/Broken.php');
+        $original = file_get_contents($srcDir . '/Broken.php');
+        $this->assertSame($original, $result);
+
+        unlink($tmpRoot . '/Broken.php');
+        rmdir($tmpRoot);
+    }
+}

--- a/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
+++ b/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
@@ -177,6 +177,10 @@ class ThrowsResolutionIntegrationTest extends TestCase
             if ($fi->isDot() || !$fi->isDir()) {
                 continue;
             }
+            if (str_starts_with($fi->getFilename(), 'app-run-malformed')) {
+                // Integration tests for malformed PHP are handled elsewhere
+                continue;
+            }
             $ignore = str_starts_with($fi->getFilename(), 'ignore-throws-annotations');
             $scenarios[] = [$fi->getFilename(), $ignore];
         }

--- a/tests/fixtures/app-run-basic/Bar.php
+++ b/tests/fixtures/app-run-basic/Bar.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\TestFixtures\AppRunBasic;
+
+class Bar
+{
+    public function call(): void
+    {
+        $f = new Foo();
+        $f->foo();
+    }
+}

--- a/tests/fixtures/app-run-basic/Foo.php
+++ b/tests/fixtures/app-run-basic/Foo.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\TestFixtures\AppRunBasic;
+
+class Foo
+{
+    public function foo(): void
+    {
+        throw new \RuntimeException();
+    }
+}

--- a/tests/fixtures/app-run-basic/expected_Bar.php
+++ b/tests/fixtures/app-run-basic/expected_Bar.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\TestFixtures\AppRunBasic;
+
+class Bar
+{
+    /**
+     * @throws \RuntimeException
+     */
+    public function call(): void
+    {
+        $f = new Foo();
+        $f->foo();
+    }
+}

--- a/tests/fixtures/app-run-basic/expected_Foo.php
+++ b/tests/fixtures/app-run-basic/expected_Foo.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\TestFixtures\AppRunBasic;
+
+class Foo
+{
+    /**
+     * @throws \RuntimeException
+     */
+    public function foo(): void
+    {
+        throw new \RuntimeException();
+    }
+}

--- a/tests/fixtures/app-run-basic/expected_results.json
+++ b/tests/fixtures/app-run-basic/expected_results.json
@@ -1,0 +1,10 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\AppRunBasic\\Foo::foo": [
+      "RuntimeException"
+    ],
+    "HenkPoley\\DocBlockDoctor\\TestFixtures\\AppRunBasic\\Bar::call": [
+      "RuntimeException"
+    ]
+  }
+}

--- a/tests/fixtures/app-run-malformed/Broken.php
+++ b/tests/fixtures/app-run-malformed/Broken.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\TestFixtures\AppRunMalformed;
+
+class Broken
+{
+    public function bad(): void
+    {
+        echo 'fail';
+// missing closing braces intentionally

--- a/tests/fixtures/app-run-malformed/expected_results.json
+++ b/tests/fixtures/app-run-malformed/expected_results.json
@@ -1,0 +1,3 @@
+{
+  "fullyQualifiedMethodKeys": {}
+}


### PR DESCRIPTION
## Summary
- create new fixtures for application run integration tests
- add tests covering missing files, write errors, and malformed PHP
- exclude malformed fixture from throw resolution tests

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68580e59949883289d175332a4cdc5fb