### PR TITLE
Add more unit tests

### DIFF
--- a/tests/Unit/ApplicationCollectPhpFilesTest.php
+++ b/tests/Unit/ApplicationCollectPhpFilesTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\Tests\Unit;
+
+use HenkPoley\DocBlockDoctor\Application;
+use HenkPoley\DocBlockDoctor\ApplicationOptions;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationCollectPhpFilesTest extends TestCase
+{
+    public function testCollectPhpFilesRecursesAndFilters(): void
+    {
+        $base = sys_get_temp_dir() . '/collect-' . uniqid();
+        mkdir($base . '/sub', 0777, true);
+        file_put_contents($base . '/a.php', '<?php');
+        file_put_contents($base . '/b.txt', '');
+        file_put_contents($base . '/sub/c.php', '<?php');
+        mkdir($base . '/sub/node_modules');
+        file_put_contents($base . '/sub/node_modules/d.php', '<?php');
+        mkdir($base . '/.git');
+        file_put_contents($base . '/.git/e.php', '<?php');
+
+        $opt = new ApplicationOptions();
+        $opt->readDirs = [$base . '/a.php', $base];
+
+        $app = new Application();
+        $ref = new \ReflectionMethod(Application::class, 'collectPhpFiles');
+        $ref->setAccessible(true);
+        $files = $ref->invoke($app, $opt);
+
+        sort($files);
+        $expected = [realpath($base . '/a.php'), realpath($base . '/sub/c.php')];
+        sort($expected);
+        $this->assertSame($expected, $files);
+    }
+}

--- a/tests/Unit/ApplicationUpdateFilesTest.php
+++ b/tests/Unit/ApplicationUpdateFilesTest.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\Tests\Unit;
+
+use HenkPoley\DocBlockDoctor\Application;
+use HenkPoley\DocBlockDoctor\ApplicationOptions;
+use HenkPoley\DocBlockDoctor\FileSystem;
+use HenkPoley\DocBlockDoctor\AstParser;
+use HenkPoley\DocBlockDoctor\AstUtils;
+use HenkPoley\DocBlockDoctor\GlobalCache;
+use HenkPoley\DocBlockDoctor\DocBlockUpdater;
+use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationUpdateFilesTest extends TestCase
+{
+    private function makeAstParser(): AstParser
+    {
+        return new class implements AstParser {
+            private $parser;
+            public function __construct()
+            {
+                $this->parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+            }
+            public function parse(string $code): ?array
+            {
+                return $this->parser->parse($code);
+            }
+            public function traverse(array $ast, array $visitors): void
+            {
+                $tr = new NodeTraverser();
+                foreach ($visitors as $v) {
+                    $tr->addVisitor($v);
+                }
+                $tr->traverse($ast);
+            }
+        };
+    }
+
+    public function testUpdateFilesAppliesPatch(): void
+    {
+        $code = "<?php\nfunction foo() {}\n";
+        $file = sys_get_temp_dir() . '/upd-' . uniqid() . '.php';
+        file_put_contents($file, $code);
+
+        $fs = new class($file, $code) implements FileSystem {
+            public array $files;
+            public array $written = [];
+            public function __construct(private string $path, string $code) { $this->files = [$path => $code]; }
+            public function getContents(string $path): string|false { return $this->files[$path] ?? false; }
+            public function putContents(string $path, string $contents): bool { $this->written[$path] = $contents; $this->files[$path] = $contents; return true; }
+            public function isFile(string $path): bool { return isset($this->files[$path]); }
+            public function isDir(string $path): bool { return false; }
+            public function realPath(string $path): string|false { return $path; }
+            public function getCurrentWorkingDirectory(): string|false { return sys_get_temp_dir(); }
+        };
+
+        $astParser = $this->makeAstParser();
+        GlobalCache::clear();
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code) ?: [];
+        $func = $ast[0];
+        GlobalCache::$astNodeMap['foo'] = $func;
+        GlobalCache::$nodeKeyToFilePath['foo'] = $file;
+        GlobalCache::$fileNamespaces[$file] = '';
+        GlobalCache::$resolvedThrows['foo'] = ['RuntimeException'];
+
+        $app = new Application($fs, $astParser);
+        $ref = new \ReflectionMethod(Application::class, 'updateFiles');
+        $ref->setAccessible(true);
+        $opt = new ApplicationOptions();
+        $opt->writeDirs = [dirname($file)];
+        $opt->verbose = false;
+        $result = $ref->invoke($app, [$file], new AstUtils(), $opt);
+
+        $this->assertSame([$file], $result);
+        $this->assertStringContainsString('@throws \\RuntimeException', $fs->files[$file]);
+    }
+
+    public function testUpdateFilesWriteFailureStillReturnsFile(): void
+    {
+        $code = "<?php\nfunction foo() {}\n";
+        $file = sys_get_temp_dir() . '/upd-' . uniqid() . '.php';
+        file_put_contents($file, $code);
+
+        $fs = new class($file, $code) implements FileSystem {
+            public array $files;
+            public bool $fail = true;
+            public array $written = [];
+            public function __construct(private string $path, string $code) { $this->files = [$path => $code]; }
+            public function getContents(string $path): string|false { return $this->files[$path] ?? false; }
+            public function putContents(string $path, string $contents): bool { $this->written[$path] = $contents; return !$this->fail; }
+            public function isFile(string $path): bool { return isset($this->files[$path]); }
+            public function isDir(string $path): bool { return false; }
+            public function realPath(string $path): string|false { return $path; }
+            public function getCurrentWorkingDirectory(): string|false { return sys_get_temp_dir(); }
+        };
+
+        $astParser = $this->makeAstParser();
+        GlobalCache::clear();
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code) ?: [];
+        $func = $ast[0];
+        GlobalCache::$astNodeMap['foo'] = $func;
+        GlobalCache::$nodeKeyToFilePath['foo'] = $file;
+        GlobalCache::$fileNamespaces[$file] = '';
+        GlobalCache::$resolvedThrows['foo'] = ['RuntimeException'];
+
+        $app = new Application($fs, $astParser);
+        $ref = new \ReflectionMethod(Application::class, 'updateFiles');
+        $ref->setAccessible(true);
+        $opt = new ApplicationOptions();
+        $opt->writeDirs = [dirname($file)];
+        $opt->verbose = false;
+        $result = $ref->invoke($app, [$file], new AstUtils(), $opt);
+
+        $this->assertSame([$file], $result);
+        $this->assertSame($code, $fs->files[$file]);
+    }
+}

--- a/tests/Unit/DocBlockUpdaterPatchTest.php
+++ b/tests/Unit/DocBlockUpdaterPatchTest.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\Tests\Unit;
+
+use HenkPoley\DocBlockDoctor\DocBlockUpdater;
+use HenkPoley\DocBlockDoctor\AstUtils;
+use HenkPoley\DocBlockDoctor\GlobalCache;
+use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
+use PHPUnit\Framework\TestCase;
+use PhpParser\NodeFinder;
+use HenkPoley\DocBlockDoctor\ThrowsGatherer;
+
+class DocBlockUpdaterPatchTest extends TestCase
+{
+    private function runUpdater(string $code, array $resolved, bool $traceOrigins = false, bool $traceCallSites = false, array $throwOrigins = []): array
+    {
+        $file = 'dummy.php';
+        GlobalCache::clear();
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code) ?: [];
+
+        $tr1 = new NodeTraverser();
+        $tr1->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $tr1->addVisitor(new ParentConnectingVisitor());
+        $finder = new NodeFinder();
+        $utils = new AstUtils();
+        foreach ($ast as $node) {
+            if ($node instanceof \PhpParser\Node\Stmt\Function_) {
+                GlobalCache::$astNodeMap[$node->name->toString()] = $node;
+                GlobalCache::$nodeKeyToFilePath[$node->name->toString()] = $file;
+            }
+        }
+        GlobalCache::$fileNamespaces[$file] = '';
+        foreach ($resolved as $key => $vals) {
+            GlobalCache::$resolvedThrows[$key] = $vals;
+        }
+        foreach ($throwOrigins as $fn => $exMap) {
+            foreach ($exMap as $ex => $chains) {
+                GlobalCache::$throwOrigins[$fn][$ex] = $chains;
+            }
+        }
+
+        $tr2 = new NodeTraverser();
+        $tr2->addVisitor(new NameResolver(null, ['replaceNodes' => false, 'preserveOriginalNames' => true]));
+        $tr2->addVisitor(new ParentConnectingVisitor());
+        $updater = new DocBlockUpdater($utils, $file, $traceOrigins, $traceCallSites);
+        $tr2->addVisitor($updater);
+        $tr2->traverse($ast);
+        return $updater->pendingPatches;
+    }
+
+    public function testAddThrowsAnnotation(): void
+    {
+        $code = "<?php\nfunction foo() { throw new \RuntimeException(); }";
+        $patches = $this->runUpdater($code, ['foo' => ['RuntimeException']]);
+        $this->assertCount(1, $patches);
+        $this->assertSame('add', $patches[0]['type']);
+        $this->assertStringContainsString('@throws \\RuntimeException', $patches[0]['newDocText']);
+    }
+
+    public function testRemoveThrowsAnnotation(): void
+    {
+        $code = "<?php\n/** @throws \\RuntimeException */\nfunction foo() {}";
+        $patches = $this->runUpdater($code, ['foo' => []]);
+        $this->assertCount(1, $patches);
+        $this->assertSame('remove', $patches[0]['type']);
+    }
+
+    public function testUpdateThrowsAnnotation(): void
+    {
+        $code = "<?php\n/** @throws \\LogicException */\nfunction foo() { throw new \RuntimeException(); }";
+        $patches = $this->runUpdater($code, ['foo' => ['RuntimeException']]);
+        $this->assertCount(1, $patches);
+        $this->assertSame('update', $patches[0]['type']);
+        $this->assertStringContainsString('@throws \\RuntimeException', $patches[0]['newDocText']);
+    }
+
+    public function testTraceOriginsIncludesChains(): void
+    {
+        $code = "<?php\nfunction foo() { throw new \\RuntimeException(); }";
+        $orig = ['foo' => ['RuntimeException' => ['dummy.php:3 <- foo']]];
+        $patches = $this->runUpdater($code, ['foo' => ['RuntimeException']], true, false, $orig);
+        $this->assertStringContainsString('dummy.php:3', $patches[0]['newDocText']);
+    }
+
+    public function testTraceCallSitesIncludesLineNumbers(): void
+    {
+        $code = "<?php\nfunction foo() { throw new \\RuntimeException(); }";
+        $orig = ['foo' => ['RuntimeException' => ['dummy.php:3 <- foo']]];
+        $patches = $this->runUpdater($code, ['foo' => ['RuntimeException']], false, true, $orig);
+        $this->assertStringContainsString(':3', $patches[0]['newDocText']);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for Application::updateFiles and collectPhpFiles
- add DocBlockUpdater patch tests for add/remove/update cases with tracing

## Testing
- `vendor/bin/phpunit --coverage-text`

------
https://chatgpt.com/codex/tasks/task_e_685817f8687483289c99238b7878f200