### PR TITLE
Implement interface exception aggregation

### DIFF
--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -47,6 +47,10 @@ class GlobalCache
      */
     public static $classTraits = [];
     /**
+     * @var array<string,string[]> Mapping of interface FQCN to implementing class FQCNs
+     */
+    public static $interfaceImplementations = [];
+    /**
      * @var array<string,array<string,string[]>> Mapping of method key to
      * exception FQCN to a list of origin call chain strings. For each method,
      * each chain starts with the call site location within that method,
@@ -70,6 +74,7 @@ class GlobalCache
         self::$throwOrigins = [];
         self::$classParents = [];
         self::$classTraits = [];
+        self::$interfaceImplementations = [];
     }
 
     /**

--- a/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
+++ b/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
@@ -157,6 +157,16 @@ class ThrowsResolutionIntegrationTest extends TestCase
                     $changed = true;
                 }
             }
+            $app = new \HenkPoley\DocBlockDoctor\Application(
+                new \HenkPoley\DocBlockDoctor\NativeFileSystem(),
+                new \HenkPoley\DocBlockDoctor\PhpParserAstParser()
+            );
+            $ref = new \ReflectionClass($app);
+            $m   = $ref->getMethod('propagateInterfaceThrows');
+            $m->setAccessible(true);
+            if ($m->invoke($app)) {
+                $changed = true;
+            }
         } while ($changed && $iteration < $maxIter);
 
         $expectedFile = $fixtureRoot . '/expected_results.json';

--- a/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
+++ b/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
@@ -111,7 +111,17 @@ class ThrowsResolutionIntegrationTest extends TestCase
                     $baseThrows = array_values(array_unique($baseThrows));
                 }
                 $throwsFromCallees = [];
-                if (isset($node->stmts) && is_array($node->stmts)) {
+                if ($node->stmts === null) {
+                    $existing = GlobalCache::$resolvedThrows[$methodKey] ?? [];
+                    $newThrows = array_values(array_unique(array_merge($baseThrows, $existing)));
+                    sort($newThrows);
+                    if ($newThrows !== (GlobalCache::$resolvedThrows[$methodKey] ?? [])) {
+                        GlobalCache::$resolvedThrows[$methodKey] = $newThrows;
+                        $changed = true;
+                    }
+                    continue;
+                }
+                if (is_array($node->stmts)) {
                     $calls = array_merge(
                         $finder->findInstanceOf($node->stmts, \PhpParser\Node\Expr\MethodCall::class),
                         $finder->findInstanceOf($node->stmts, \PhpParser\Node\Expr\StaticCall::class),

--- a/tests/fixtures/interface-implementers/FirstImplementer.php
+++ b/tests/fixtures/interface-implementers/FirstImplementer.php
@@ -1,0 +1,7 @@
+<?php
+namespace Pitfalls\InterfaceImplementers;
+class FirstImplementer implements FooImplementer {
+    public function foo(): void {
+        throw new \RuntimeException();
+    }
+}

--- a/tests/fixtures/interface-implementers/FooImplementer.php
+++ b/tests/fixtures/interface-implementers/FooImplementer.php
@@ -1,0 +1,5 @@
+<?php
+namespace Pitfalls\InterfaceImplementers;
+interface FooImplementer {
+    public function foo(): void;
+}

--- a/tests/fixtures/interface-implementers/Runner.php
+++ b/tests/fixtures/interface-implementers/Runner.php
@@ -1,0 +1,11 @@
+<?php
+namespace Pitfalls\InterfaceImplementers;
+class Runner {
+    private FooImplementer $impl;
+    public function __construct(FooImplementer $impl) {
+        $this->impl = $impl;
+    }
+    public function run(): void {
+        $this->impl->foo();
+    }
+}

--- a/tests/fixtures/interface-implementers/SecondImplementer.php
+++ b/tests/fixtures/interface-implementers/SecondImplementer.php
@@ -1,0 +1,7 @@
+<?php
+namespace Pitfalls\InterfaceImplementers;
+class SecondImplementer implements FooImplementer {
+    public function foo(): void {
+        throw new \LogicException();
+    }
+}

--- a/tests/fixtures/interface-implementers/expected_results.json
+++ b/tests/fixtures/interface-implementers/expected_results.json
@@ -1,0 +1,18 @@
+{
+  "fullyQualifiedMethodKeys": {
+    "Pitfalls\\InterfaceImplementers\\FooImplementer::foo": [
+      "LogicException",
+      "RuntimeException"
+    ],
+    "Pitfalls\\InterfaceImplementers\\FirstImplementer::foo": [
+      "RuntimeException"
+    ],
+    "Pitfalls\\InterfaceImplementers\\SecondImplementer::foo": [
+      "LogicException"
+    ],
+    "Pitfalls\\InterfaceImplementers\\Runner::run": [
+      "LogicException",
+      "RuntimeException"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- map interface implementations in GlobalCache
- gather class `implements` info in ThrowsGatherer
- propagate throws from implementing classes to interface methods during resolution
- ensure integration tests emulate interface propagation
- add new fixture for interface implementations

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685822bf726c832899aa1227c9188755