### PR TITLE
Ignore @throws lines with comments

### DIFF
--- a/tests/NewIntegration/UnnecessaryThrowsAnnotationsTest.php
+++ b/tests/NewIntegration/UnnecessaryThrowsAnnotationsTest.php
@@ -25,7 +25,9 @@ class UnnecessaryThrowsAnnotationsTest extends TestCase
 
         $original = file_get_contents($fullPath);
         $this->assertNotFalse($original);
-        $stripped = preg_replace('/^\s*\*\s*@throws.*$/m', '', $original);
+        // Only remove @throws lines that contain just the exception class name
+        // so lines with extra comment text remain untouched
+        $stripped = preg_replace('/^\s*\*\s*@throws\s+[^\s]+(?:\|[^\s]+)*\s*$/m', '', $original);
         if ($stripped === null) {
             $stripped = $original;
         }


### PR DESCRIPTION
## Summary
- refine regex in `UnnecessaryThrowsAnnotationsTest` to only strip `@throws` lines that contain just the exception class name

## Testing
- `./vendor/bin/phpunit -c phpunit.xml` *(fails: Unnecessary @throws tags in several scenarios)*

------
https://chatgpt.com/codex/tasks/task_e_685844f83a2c832883b7a582f939a9e8