### PR TITLE
Improve fixture error messages

### DIFF
--- a/tests/NewIntegration/ApplicationRunFixtureProjectsTest.php
+++ b/tests/NewIntegration/ApplicationRunFixtureProjectsTest.php
@@ -27,10 +27,23 @@ class ApplicationRunFixtureProjectsTest extends TestCase
         $this->assertStringContainsString('=== Summary ===', $output);
 
         foreach ($files as $file) {
-            $expected = file_get_contents($srcDir . '/expected_' . $file);
-            $this->assertNotFalse($expected);
-            $actual = file_get_contents($tmpRoot . '/' . $file);
-            $this->assertSame($expected, $actual, $file . ' mismatch');
+            $expectedPath = $srcDir . '/expected_' . $file;
+            $expected     = file_get_contents($expectedPath);
+            $this->assertNotFalse(
+                $expected,
+                'Failed to read expected file: ' . $expectedPath
+            );
+            $actualPath = $tmpRoot . '/' . $file;
+            $actual     = file_get_contents($actualPath);
+            $this->assertNotFalse(
+                $actual,
+                'Failed to read temporary file: ' . $actualPath
+            );
+            $this->assertSame(
+                $expected,
+                $actual,
+                $actualPath . ' mismatch'
+            );
             unlink($tmpRoot . '/' . $file);
         }
         rmdir($tmpRoot);

--- a/tests/NewIntegration/ApplicationRunIntegrationTest.php
+++ b/tests/NewIntegration/ApplicationRunIntegrationTest.php
@@ -15,8 +15,11 @@ class ApplicationRunIntegrationTest extends TestCase
     {
         $tmpRoot = sys_get_temp_dir() . '/docblockdoctor-run-' . uniqid();
         mkdir($tmpRoot);
-        copy(__DIR__ . '/../fixtures/single-line-method-docblock/InlineDocblock.php', $tmpRoot . '/InlineDocblock.php');
-        $expected = file_get_contents(__DIR__ . '/../fixtures/single-line-method-docblock/expected_rewritten.php');
+        $fixture = __DIR__ . '/../fixtures/single-line-method-docblock/InlineDocblock.php';
+        copy($fixture, $tmpRoot . '/InlineDocblock.php');
+        $expectedPath = __DIR__ . '/../fixtures/single-line-method-docblock/expected_rewritten.php';
+        $expected = file_get_contents($expectedPath);
+        $this->assertNotFalse($expected, 'Failed to read expected file: ' . $expectedPath);
 
         $app = new Application();
         ob_start();
@@ -27,8 +30,10 @@ class ApplicationRunIntegrationTest extends TestCase
         $this->assertStringContainsString('Files read (1):', $output);
         $this->assertStringContainsString('Files fixed (1):', $output);
 
-        $result = file_get_contents($tmpRoot . '/InlineDocblock.php');
-        $this->assertSame($expected, $result);
+        $resultPath = $tmpRoot . '/InlineDocblock.php';
+        $result = file_get_contents($resultPath);
+        $this->assertNotFalse($result, 'Failed to read rewritten file: ' . $resultPath);
+        $this->assertSame($expected, $result, $resultPath . ' mismatch');
 
         unlink($tmpRoot . '/InlineDocblock.php');
         rmdir($tmpRoot);

--- a/tests/NewIntegration/DocBlockUpdaterIntegrationTest.php
+++ b/tests/NewIntegration/DocBlockUpdaterIntegrationTest.php
@@ -33,7 +33,10 @@ class DocBlockUpdaterIntegrationTest extends TestCase
 
         // 1) Read input
         $code = file_get_contents($inputFile);
-        $this->assertNotFalse($code);
+        $this->assertNotFalse(
+            $code,
+            'Failed to read fixture file: ' . $inputFile
+        );
 
         // 2) First pass: gather throws + build GlobalCache
         GlobalCache::clear();
@@ -159,8 +162,15 @@ class DocBlockUpdaterIntegrationTest extends TestCase
 
         // 6) Compare with expected rewritten code
         $expectedCode = file_get_contents($expectedOut);
-        $this->assertNotFalse($expectedCode);
-        $this->assertSame($expectedCode, $patchedCode, 'Rewritten code did not match expected for docblock rewrite');
+        $this->assertNotFalse(
+            $expectedCode,
+            'Failed to read expected file: ' . $expectedOut
+        );
+        $this->assertSame(
+            $expectedCode,
+            $patchedCode,
+            'Rewritten code did not match expected for ' . $inputFile
+        );
     }
 
     public static function fixtureProvider(): array

--- a/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
+++ b/tests/NewIntegration/ThrowsResolutionIntegrationTest.php
@@ -49,7 +49,10 @@ class ThrowsResolutionIntegrationTest extends TestCase
         $this->runApplicationPhases($phpFiles, $ignoreAnnotated);
 
         $expectedFile = $fixtureRoot . '/expected_results.json';
-        $this->assertFileExists($expectedFile);
+        $this->assertFileExists(
+            $expectedFile,
+            'Missing expected results file: ' . $expectedFile
+        );
         $expectedData = json_decode(file_get_contents($expectedFile), true, 512, JSON_THROW_ON_ERROR);
         $allResolved = GlobalCache::getAllResolvedThrows();
         foreach ($expectedData['fullyQualifiedMethodKeys'] as $methodKey => $throws) {

--- a/tests/NewIntegration/UnnecessaryThrowsAnnotationsTest.php
+++ b/tests/NewIntegration/UnnecessaryThrowsAnnotationsTest.php
@@ -24,7 +24,10 @@ class UnnecessaryThrowsAnnotationsTest extends TestCase
         $fullPath    = $fixtureRoot . '/' . $relativeFile;
 
         $original = file_get_contents($fullPath);
-        $this->assertNotFalse($original);
+        $this->assertNotFalse(
+            $original,
+            'Failed to read fixture file: ' . $fullPath
+        );
         if (preg_match('/^\s*\*\s*@throws\s+[^\s]+(?:\|[^\s]+)*\s+.+$/m', $original)) {
             // Ignore functions where the @throws annotation has inline comments
             // They are considered intentionally documented regardless of necessity
@@ -41,7 +44,10 @@ class UnnecessaryThrowsAnnotationsTest extends TestCase
         $actual = $this->gatherResolvedThrowsForScenario($scenario, [$fullPath => $stripped]);
 
         $expectedFile = $fixtureRoot . '/expected_results.json';
-        $this->assertFileExists($expectedFile);
+        $this->assertFileExists(
+            $expectedFile,
+            'Expected results missing for scenario ' . $scenario
+        );
         $expectedData = json_decode(file_get_contents($expectedFile), true, 512, JSON_THROW_ON_ERROR);
 
         $allSame = true;


### PR DESCRIPTION
## Summary
- show file paths in test failures when reading fixture files

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6858d3333a5c8328a81d5b775d3a428f