### PR TITLE
Run psalm fixes

### DIFF
--- a/src/DocBlockUpdater.php
+++ b/src/DocBlockUpdater.php
@@ -145,12 +145,12 @@ class DocBlockUpdater extends NodeVisitorAbstract
                 $isFirst = ($lineIdx === 0 && preg_match('/^\s*\/\*\*/', $currentDocLine));
                 $isLast  = ($lineIdx === count($originalLines) - 1 && preg_match('/\*\/\s*$/', $currentDocLine));
                 if ($isFirst) {
-                    $currentDocLine = preg_replace('/^\s*\/\*\*\s?/', '', $currentDocLine);
+                    $currentDocLine = (string) preg_replace('/^\s*\/\*\*\s?/', '', $currentDocLine);
                 }
                 if ($isLast) {
-                    $currentDocLine = preg_replace('/\s*\*\/$/', '', $currentDocLine);
+                    $currentDocLine = (string) preg_replace('/\s*\*\/$/', '', $currentDocLine);
                 }
-                $lineContent = preg_replace('/^\s*\*?\s?/', '', $currentDocLine);
+                $lineContent = preg_replace('/^\s*\*?\s?/', '', (string) $currentDocLine);
                 $trimmedLineContent = trim((string)$lineContent);
 
                 if (preg_match('/^@throws\s/i', $trimmedLineContent)) {
@@ -229,7 +229,7 @@ class DocBlockUpdater extends NodeVisitorAbstract
                         } elseif (preg_match('/^(.*?:\d+) <- ' . preg_quote($nodeKey, '/') . ' <- (.*)$/', $ch, $m)) {
                             $ch = $m[1] . ' <- ' . $m[2];
                         }
-                        $parts = explode(' <- ', $ch);
+                        $parts = explode(' <- ', (string) $ch);
                         $first = $parts[0] ?? '';
                         if (preg_match('/:(\d+)$/', $first, $m2)) {
                             $lines[] = (int)$m2[1];
@@ -281,12 +281,12 @@ class DocBlockUpdater extends NodeVisitorAbstract
                     $isFirst = ($i === 0 && preg_match('/^\s*\/\*\*/', $line));
                     $isLast  = ($i === count($lines) - 1 && preg_match('/\*\/\s*$/', $line));
                     if ($isFirst) {
-                        $line = preg_replace('/^\s*\/\*\*\s?/', '', $line);
+                        $line = (string) preg_replace('/^\s*\/\*\*\s?/', '', $line);
                     }
                     if ($isLast) {
-                        $line = preg_replace('/\s*\*\/$/', '', $line);
+                        $line = (string) preg_replace('/\s*\*\/$/', '', $line);
                     }
-                    $line = preg_replace('/^\s*\*?\s?/', '', $line);
+                    $line = (string) preg_replace('/^\s*\*?\s?/', '', $line);
                     $originalContentOnlyLines[] = $line;
                 }
                 $originalTextToNormalize = implode("\n", $originalContentOnlyLines);

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -9,7 +9,6 @@ interface FileSystem
      */
     public function getContents(string $path);
 
-    /** @psalm-suppress PossiblyUnusedReturnValue */
     public function putContents(string $path, string $contents): bool;
 
     public function isFile(string $path): bool;

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -9,6 +9,7 @@ interface FileSystem
      */
     public function getContents(string $path);
 
+    /** @psalm-suppress PossiblyUnusedReturnValue */
     public function putContents(string $path, string $contents): bool;
 
     public function isFile(string $path): bool;

--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -266,13 +266,11 @@ class ThrowsGatherer extends NodeVisitorAbstract
                         $fqcns[] = $thrownFqcn;
                         $loc = $this->filePath . ':' . $throwExpr->getStartLine();
                         $chain = $funcKey . ' <- ' . $loc;
-                        if (!isset(\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn])) {
-                            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn] = [];
-                        }
-                        $origins = &\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn];
+                        $origins = \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn] ?? [];
                         if (!in_array($chain, $origins, true) && count($origins) < \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS) {
                             $origins[] = $chain;
                         }
+                        \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn] = $origins;
                     }
                 } elseif ($newExpr->class instanceof Node\Expr\Variable) {
                     $varName = $newExpr->class->name;
@@ -292,13 +290,11 @@ class ThrowsGatherer extends NodeVisitorAbstract
                             $fqcns[] = $classFqcn;
                             $loc = $this->filePath . ':' . $throwExpr->getStartLine();
                             $chain = $funcKey . ' <- ' . $loc;
-                            if (!isset(\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$classFqcn])) {
-                                \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$classFqcn] = [];
-                            }
-                            $origins = &\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$classFqcn];
+                            $origins = \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$classFqcn] ?? [];
                             if (!in_array($chain, $origins, true) && count($origins) < \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS) {
                                 $origins[] = $chain;
                             }
+                            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$classFqcn] = $origins;
                         }
                     }
                 }
@@ -325,13 +321,11 @@ class ThrowsGatherer extends NodeVisitorAbstract
                                     $fqcns[] = $thrownFqcn;
                                     $loc = $this->filePath . ':' . $throwExpr->getStartLine();
                                     $chain = $funcKey . ' <- ' . $loc;
-                                    if (!isset(\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn])) {
-                                        \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn] = [];
-                                    }
-                                    $origins = &\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn];
+                                    $origins = \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn] ?? [];
                                     if (!in_array($chain, $origins, true) && count($origins) < \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS) {
                                         $origins[] = $chain;
                                     }
+                                    \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$thrownFqcn] = $origins;
                                 }
                             }
                         }
@@ -344,13 +338,11 @@ class ThrowsGatherer extends NodeVisitorAbstract
                             $fqcns[] = $fq;
                             $loc = $this->filePath . ':' . $throwExpr->getStartLine();
                             $chain = $funcKey . ' <- ' . $loc;
-                            if (!isset(\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq])) {
-                                \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq] = [];
-                            }
-                            $origins = &\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq];
+                            $origins = \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq] ?? [];
                             if (!in_array($chain, $origins, true) && count($origins) < \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS) {
                                 $origins[] = $chain;
                             }
+                            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fq] = $origins;
                         }
                     }
                 }
@@ -452,8 +444,8 @@ class ThrowsGatherer extends NodeVisitorAbstract
         $bestFqcn = null;
         foreach ($assigns as $assign) {
             if ($assign->var instanceof Node\Expr\Variable && $assign->var->name === $varName) {
-                $pos = $assign->getStartFilePos() ?? -1;
-                $refPos = $reference->getStartFilePos() ?? 0;
+                $pos = $assign->getStartFilePos();
+                $refPos = $reference->getStartFilePos();
                 if ($pos >= $refPos) {
                     continue;
                 }

--- a/src/UseStatementSimplifierSurgical.php
+++ b/src/UseStatementSimplifierSurgical.php
@@ -68,11 +68,11 @@ class UseStatementSimplifierSurgical extends NodeVisitorAbstract
             $phpPrefixSpaceNewline = "<?php \n";
 
             if (strncmp($replacementCode, $phpPrefixSpaceNewline, strlen($phpPrefixSpaceNewline)) === 0) {
-                $replacementCode = substr($replacementCode, strlen($phpPrefixSpaceNewline));
+                $replacementCode = (string) substr($replacementCode, strlen($phpPrefixSpaceNewline));
             } elseif (strncmp($replacementCode, $phpPrefixNewline, strlen($phpPrefixNewline)) === 0) {
-                $replacementCode = substr($replacementCode, strlen($phpPrefixNewline));
+                $replacementCode = (string) substr($replacementCode, strlen($phpPrefixNewline));
             } elseif (strncmp($replacementCode, $phpPrefixSpace, strlen($phpPrefixSpace)) === 0) {
-                $replacementCode = substr($replacementCode, strlen($phpPrefixSpace));
+                $replacementCode = (string) substr($replacementCode, strlen($phpPrefixSpace));
             }
 
             // Ensure it ends with a newline, as use statements are typically on their own line.


### PR DESCRIPTION
## Summary
- remove unreachable check for null parameter values
- avoid redundant conditions and unnecessary annotations
- ensure string inputs when using `substr` and `explode`
- tighten iteration over implementation lists
- clean up comment parsing in DocBlock updater
- suppress unused return warnings for the FileSystem interface

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml`
- `./vendor/bin/psalm --no-cache` *(fails: PossiblyUnusedMethod, UnsupportedPropertyReferenceUsage, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6858d63d582483288983426a55e9a10c