### PR TITLE
Fix Psalm info warnings by improving typing

### DIFF
--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -2,76 +2,80 @@
 
 namespace HenkPoley\DocBlockDoctor;
 
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+
 class GlobalCache
 {
     /** Max number of origin call chains stored per exception */
     public const MAX_ORIGIN_CHAINS = 5;
 
     /**
-     * @var mixed[]
+     * @var array<string, string[]>
      */
-    public static $directThrows = [];
+    public static array $directThrows = [];
 
     /**
-     * @var mixed[]
+     * @var array<string, string[]>
      */
-    public static $annotatedThrows = [];
+    public static array $annotatedThrows = [];
 
     /**
-     * @var mixed[]
+     * @var array<string, array<string, string>>
      */
-    public static $originalDescriptions = [];
+    public static array $originalDescriptions = [];
 
     /**
-     * @var mixed[]
+     * @var array<string, string>
      */
-    public static $fileNamespaces = [];
+    public static array $fileNamespaces = [];
 
     /**
-     * @var mixed[]
+     * @var array<string, array<string, string>>
      */
-    public static $fileUseMaps = [];
+    public static array $fileUseMaps = [];
 
     /**
-     * @var mixed[]
+     * @var array<string, Function_|ClassMethod>
      */
-    public static $astNodeMap = [];
+    public static array $astNodeMap = [];
 
     /**
-     * @var mixed[]
+     * @var array<string, string>
      */
-    public static $nodeKeyToFilePath = [];
+    public static array $nodeKeyToFilePath = [];
 
     /**
-     * @var mixed[]
+     * @var array<string, string[]>
      */
-    public static $resolvedThrows = [];
+    public static array $resolvedThrows = [];
 
     /**
-     * @var array<string,string|null> Mapping of class FQCN to its parent class FQCN
+     * @var array<string, string|null> Mapping of class FQCN to its parent class FQCN
      */
-    public static $classParents = [];
+    public static array $classParents = [];
 
     /**
      * @var array<string,string[]> Mapping of class FQCN to the traits it uses
      */
-    public static $classTraits = [];
+    public static array $classTraits = [];
 
     /**
      * @var array<string,string[]> Mapping of interface FQCN to implementing class FQCNs
      */
-    public static $interfaceImplementations = [];
+    public static array $interfaceImplementations = [];
 
     /**
-     * @var array<string,array<string,string[]>> Mapping of method key to
-     * exception FQCN to a list of origin call chain strings. For each method,
-     * each chain starts with the call site location within that method,
-     * followed by the sequence of callee method names in order of invocation
-     * and ends with the file and line where the exception was originally
-     * thrown. Example:
-     * "src/File.php:10 <- SomeClass::method <- Other::callee <- vendor/lib.php:5".
+     * @var array<string, array<string, string[]>> Mapping of method key to
+     *     exception FQCN to a list of origin call chain strings. For each method,
+     *     each chain starts with the call site location within that method,
+     *     followed by the sequence of callee method names in order of invocation
+     *     and ends with the file and line where the exception was originally
+     *     thrown. Example:
+     *     "src/File.php:10 <- SomeClass::method <- Other::callee <- vendor/lib.php:5".
      */
-    public static $throwOrigins = [];
+    public static array $throwOrigins = [];
 
     public static function clear(): void
     {
@@ -90,7 +94,7 @@ class GlobalCache
     }
 
     /**
-     * @return mixed[]
+     * @return string[]
      */
     public static function getResolvedThrowsForKey(string $key): array
     {
@@ -98,7 +102,7 @@ class GlobalCache
     }
 
     /**
-     * @return mixed[]
+     * @return array<string, string[]>
      */
     public static function getThrowOriginsForKey(string $key): array
     {
@@ -106,7 +110,7 @@ class GlobalCache
     }
 
     /**
-     * @return array<string, mixed[]>
+     * @return array<string, string[]>
      */
     public static function getAllResolvedThrows(): array
     {


### PR DESCRIPTION
## Summary
- clarify resolved throw key detection
- refine collectPhpFiles typing
- add detailed array types in `GlobalCache`

## Testing
- `./vendor/bin/psalm --no-cache --error-level=2 --show-info=true`

------
https://chatgpt.com/codex/tasks/task_e_68590f12f230832881ef688720d33fee