### PR TITLE
Add GlobalCache class parent accessors

### DIFF
--- a/src/AstUtils.php
+++ b/src/AstUtils.php
@@ -868,7 +868,7 @@ class AstUtils
         if (class_exists($fqcn, false) || interface_exists($fqcn, false)) {
             return true;
         }
-        if (isset(\HenkPoley\DocBlockDoctor\GlobalCache::$classParents[$fqcn])) {
+        if (\HenkPoley\DocBlockDoctor\GlobalCache::getClassParent($fqcn) !== null) {
             return true;
         }
         $autoloaders = spl_autoload_functions();
@@ -949,7 +949,7 @@ class AstUtils
                     break;
                 }
             }
-            $current = GlobalCache::$classParents[$current] ?? null;
+            $current = GlobalCache::getClassParent($current);
         }
 
         return null;
@@ -1181,7 +1181,7 @@ class AstUtils
                 return true;
             }
             $visited[] = $current;
-            $current = GlobalCache::$classParents[$current] ?? null;
+            $current = GlobalCache::getClassParent($current);
         }
 
         return false;

--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -57,7 +57,7 @@ class GlobalCache
     /**
      * @var array<string, string|null> Mapping of class FQCN to its parent class FQCN
      */
-    public static array $classParents = [];
+    private static array $classParents = [];
 
     /**
      * @var array<string,string[]> Mapping of class FQCN to the traits it uses
@@ -202,5 +202,24 @@ class GlobalCache
     public static function setFilePathForKey(string $key, string $path): void
     {
         self::$nodeKeyToFilePath[$key] = $path;
+    }
+
+    /**
+     * @return array<string,string|null>
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public static function getClassParents(): array
+    {
+        return self::$classParents;
+    }
+
+    public static function getClassParent(string $class): ?string
+    {
+        return self::$classParents[$class] ?? null;
+    }
+
+    public static function setClassParent(string $class, ?string $parent): void
+    {
+        self::$classParents[$class] = $parent;
     }
 }

--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -95,7 +95,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
                     $parentFqcn = $this->astUtils->resolveNameNodeToFqcn($node->extends, $this->currentNamespace, $this->useMap, false);
                 }
                 $classKey = $className;
-                \HenkPoley\DocBlockDoctor\GlobalCache::$classParents[$classKey] = $parentFqcn;
+                \HenkPoley\DocBlockDoctor\GlobalCache::setClassParent($classKey, $parentFqcn);
                 foreach ($node->implements as $iface) {
                     $ifaceFqcn = $this->astUtils->resolveNameNodeToFqcn($iface, $this->currentNamespace, $this->useMap, false);
                     if ($ifaceFqcn !== '') {

--- a/tests/NewIntegration/UnnecessaryThrowsAnnotationsTest.php
+++ b/tests/NewIntegration/UnnecessaryThrowsAnnotationsTest.php
@@ -162,14 +162,14 @@ class UnnecessaryThrowsAnnotationsTest extends TestCase
             GlobalCache::$directThrows[$methodKey] = array_values(array_filter(
                 $throws,
                 static fn(string $fqcn): bool => AstUtils::classOrInterfaceExistsNoAutoload($fqcn)
-                    || isset(GlobalCache::$classParents[$fqcn])
+                    || array_key_exists($fqcn, GlobalCache::getClassParents())
             ));
         }
         foreach (GlobalCache::$resolvedThrows as $methodKey => $throws) {
             GlobalCache::$resolvedThrows[$methodKey] = array_values(array_filter(
                 $throws,
                 static fn(string $fqcn): bool => AstUtils::classOrInterfaceExistsNoAutoload($fqcn)
-                    || isset(GlobalCache::$classParents[$fqcn])
+                    || array_key_exists($fqcn, GlobalCache::getClassParents())
             ));
         }
 

--- a/tests/Unit/AstUtilsTest.php
+++ b/tests/Unit/AstUtilsTest.php
@@ -1483,7 +1483,7 @@ class AstUtilsTest extends TestCase
         });
         $traverser->traverse($ast);
 
-        GlobalCache::$classParents['SCI\\Child'] = 'SCI\\ParentClass';
+        GlobalCache::setClassParent('SCI\\Child', 'SCI\\ParentClass');
 
         $run = $this->finder->findFirst($ast, fn(Node $n) => $n instanceof Node\Stmt\ClassMethod && $n->name->toString() === 'run');
         $this->assertNotNull($run);


### PR DESCRIPTION
## Summary
- encapsulate class parent mappings in `GlobalCache`
- update `ThrowsGatherer` and `AstUtils` to use new accessors
- adjust tests for new API
- move test for class parent cache into `UseMapTest`
- make class parent cache private

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/psalm --no-cache`


------
https://chatgpt.com/codex/tasks/task_e_685a9dbe3c648328a05220fee88b82ec