### PR TITLE
Add interface implementation cache API

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -510,7 +510,7 @@ class Application
     private function propagateInterfaceThrows(): bool
     {
         $changed = false;
-        foreach (GlobalCache::$interfaceImplementations as $iface => $impls) {
+        foreach (GlobalCache::getInterfaceImplementations() as $iface => $impls) {
             $impls = array_values(array_unique($impls));
             $ifacePrefix = ltrim($iface, '\\') . '::';
             foreach (array_keys(GlobalCache::getAstNodeMap()) as $key) {

--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -67,7 +67,7 @@ class GlobalCache
     /**
      * @var array<string,string[]> Mapping of interface FQCN to implementing class FQCNs
      */
-    public static array $interfaceImplementations = [];
+    private static array $interfaceImplementations = [];
 
     /**
      * @var array<string, array<string, string[]>> Mapping of method key to
@@ -243,5 +243,28 @@ class GlobalCache
     public static function addTraitForClass(string $class, string $trait): void
     {
         self::$classTraits[$class][] = $trait;
+    }
+
+    /**
+     * @return array<string,string[]>
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public static function getInterfaceImplementations(): array
+    {
+        return self::$interfaceImplementations;
+    }
+
+    /**
+     * @return string[]
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public static function getImplementations(string $interface): array
+    {
+        return self::$interfaceImplementations[$interface] ?? [];
+    }
+
+    public static function addImplementation(string $interface, string $class): void
+    {
+        self::$interfaceImplementations[$interface][] = $class;
     }
 }

--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -99,9 +99,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
                 foreach ($node->implements as $iface) {
                     $ifaceFqcn = $this->astUtils->resolveNameNodeToFqcn($iface, $this->currentNamespace, $this->useMap, false);
                     if ($ifaceFqcn !== '') {
-                        $impls = \HenkPoley\DocBlockDoctor\GlobalCache::$interfaceImplementations[$ifaceFqcn] ?? [];
-                        $impls[] = $className;
-                        \HenkPoley\DocBlockDoctor\GlobalCache::$interfaceImplementations[$ifaceFqcn] = $impls;
+                        \HenkPoley\DocBlockDoctor\GlobalCache::addImplementation($ifaceFqcn, $className);
                     }
                 }
                 foreach ($node->stmts as $stmt) {
@@ -126,7 +124,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
                     $parentIface = $this->astUtils->resolveNameNodeToFqcn($iface, $this->currentNamespace, $this->useMap, false);
                     if ($parentIface !== '') {
                         // treat extended interfaces as having this interface as implementer
-                        \HenkPoley\DocBlockDoctor\GlobalCache::$interfaceImplementations[$parentIface][] = $interfaceName;
+                        \HenkPoley\DocBlockDoctor\GlobalCache::addImplementation($parentIface, $interfaceName);
                     }
                 }
             }

--- a/tests/Unit/UseMapTest.php
+++ b/tests/Unit/UseMapTest.php
@@ -255,4 +255,35 @@ class UseMapTest extends TestCase
         foreach ($expected as $k => $v) { sort($v); $expected[$k] = $v; }
         $this->assertSame($expected, $map);
     }
+
+    /**
+     * @throws \LogicException
+     */
+    public function testThrowsGathererCachesInterfaceImplementations(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace NS;
+        interface Base {}
+        interface Sub extends Base {}
+        class A implements Base {}
+        class B implements Sub {}
+        PHP;
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code) ?: [];
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new ThrowsGatherer($this->finder, $this->utils, 'iface.php'));
+        $traverser->traverse($ast);
+
+        $expected = [
+            'NS\\Base' => ['NS\\A', 'NS\\Sub'],
+            'NS\\Sub' => ['NS\\B'],
+        ];
+        $map = GlobalCache::getInterfaceImplementations();
+        ksort($map);
+        foreach ($map as $k => $v) { sort($v); $map[$k] = $v; }
+        ksort($expected);
+        foreach ($expected as $k => $v) { sort($v); $expected[$k] = $v; }
+        $this->assertSame($expected, $map);
+    }
 }


### PR DESCRIPTION
## Summary
- provide new accessors for interface implementation cache
- update application and throws gatherer to use new API
- verify interface implementations via UseMapTest

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/psalm --no-progress --output-format=console`

------
https://chatgpt.com/codex/tasks/task_e_685aa80c13688328a8b931a3ff1238d5