### PR TITLE
Encapsulate directThrows cache

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -361,7 +361,7 @@ class Application
 
         GlobalCache::$resolvedThrows = [];
         foreach (array_keys(GlobalCache::getAstNodeMap()) as $funcKey) {
-            $direct    = GlobalCache::$directThrows[$funcKey]    ?? [];
+            $direct    = GlobalCache::getDirectThrowsForKey($funcKey);
             $annotated = GlobalCache::$annotatedThrows[$funcKey] ?? [];
             $initial   = $direct;
             if (!$opt->ignoreAnnotatedThrows) {
@@ -393,7 +393,7 @@ class Application
                 $callerNamespace = GlobalCache::getFileNamespace($filePathOfFunc);
                 $callerUseMap    = GlobalCache::getFileUseMap($filePathOfFunc);
 
-                $baseThrows = GlobalCache::$directThrows[$funcKey] ?? [];
+                $baseThrows = GlobalCache::getDirectThrowsForKey($funcKey);
                 if (!$opt->ignoreAnnotatedThrows) {
                     $baseThrows = array_values(array_unique(array_merge(
                         $baseThrows,

--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -17,7 +17,7 @@ class GlobalCache
     /**
      * @var array<string, string[]>
      */
-    public static array $directThrows = [];
+    private static array $directThrows = [];
 
     /**
      * @var array<string, string[]>
@@ -94,6 +94,39 @@ class GlobalCache
         self::$classParents = [];
         self::$classTraits = [];
         self::$interfaceImplementations = [];
+    }
+
+    /**
+     * @return array<string,string[]>
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public static function getDirectThrows(): array
+    {
+        return self::$directThrows;
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getDirectThrowsForKey(string $key): array
+    {
+        return self::$directThrows[$key] ?? [];
+    }
+
+    /**
+     * @param string[] $throws
+     */
+    public static function setDirectThrowsForKey(string $key, array $throws): void
+    {
+        self::$directThrows[$key] = $throws;
+    }
+
+    /**
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public static function addDirectThrow(string $key, string $exception): void
+    {
+        self::$directThrows[$key][] = $exception;
     }
 
     /**

--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -141,7 +141,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
         }
         \HenkPoley\DocBlockDoctor\GlobalCache::setAstNode($key, $node);
         \HenkPoley\DocBlockDoctor\GlobalCache::setFilePathForKey($key, $this->filePath);
-        \HenkPoley\DocBlockDoctor\GlobalCache::$directThrows[$key] = [];
+        \HenkPoley\DocBlockDoctor\GlobalCache::setDirectThrowsForKey($key, []);
         \HenkPoley\DocBlockDoctor\GlobalCache::$originalDescriptions[$key] = [];
         $currentAnnotatedThrowsFqcns = [];
 
@@ -211,8 +211,10 @@ class ThrowsGatherer extends NodeVisitorAbstract
         if ($key === null || $key === '') {
             return null;
         }
-        \HenkPoley\DocBlockDoctor\GlobalCache::$directThrows[$key] =
-            $this->calculateDirectThrowsForNode($node, $key);
+        \HenkPoley\DocBlockDoctor\GlobalCache::setDirectThrowsForKey(
+            $key,
+            $this->calculateDirectThrowsForNode($node, $key)
+        );
 
         return null;
     }

--- a/tests/NewIntegration/DocBlockUpdaterIntegrationTest.php
+++ b/tests/NewIntegration/DocBlockUpdaterIntegrationTest.php
@@ -54,7 +54,7 @@ class DocBlockUpdaterIntegrationTest extends TestCase
         // 3) Intermediate: propagate throws
         $directKeys = array_keys(GlobalCache::getAstNodeMap());
         foreach ($directKeys as $methodKey) {
-            $direct    = GlobalCache::$directThrows[$methodKey] ?? [];
+            $direct    = GlobalCache::getDirectThrowsForKey($methodKey);
             $annotated = GlobalCache::$annotatedThrows[$methodKey] ?? [];
             $initial   = array_values(array_unique(array_merge($direct, $annotated)));
             sort($initial);
@@ -67,7 +67,7 @@ class DocBlockUpdaterIntegrationTest extends TestCase
             $itCount++;
             foreach (GlobalCache::getAstNodeMap() as $methodKey => $node) {
                 $allBase = array_values(array_unique(array_merge(
-                    GlobalCache::$directThrows[$methodKey]    ?? [],
+                    GlobalCache::getDirectThrowsForKey($methodKey),
                     GlobalCache::$annotatedThrows[$methodKey] ?? []
                 )));
                 sort($allBase);

--- a/tests/Unit/ApplicationFileMethodsTest.php
+++ b/tests/Unit/ApplicationFileMethodsTest.php
@@ -238,7 +238,7 @@ class ApplicationFileMethodsTest extends TestCase
         GlobalCache::setFilePathForKey('foo', 'dummy.php');
         GlobalCache::setFileNamespace('dummy.php', '');
         GlobalCache::setFileUseMap('dummy.php', []);
-        GlobalCache::$directThrows['foo'] = ['RuntimeException'];
+        GlobalCache::setDirectThrowsForKey('foo', ['RuntimeException']);
         GlobalCache::$resolvedThrows['foo'] = [];
 
         $app = new Application();

--- a/tests/Unit/AutoloadingTest.php
+++ b/tests/Unit/AutoloadingTest.php
@@ -62,7 +62,7 @@ class AutoloadingTest extends TestCase
 
         $this->assertFalse($autoloadCalled, 'Autoloader should not be called');
         // Non-existent classes should be filtered out
-        $this->assertSame([], GlobalCache::$directThrows['foo'] ?? []);
+        $this->assertSame([], GlobalCache::getDirectThrowsForKey('foo'));
     }
 
     /**

--- a/tests/Unit/CallCatchPropagationTest.php
+++ b/tests/Unit/CallCatchPropagationTest.php
@@ -52,7 +52,7 @@ class CallCatchPropagationTest extends TestCase
         $tr1->traverse($ast);
 
         foreach (array_keys(GlobalCache::getAstNodeMap()) as $key) {
-            $direct    = GlobalCache::$directThrows[$key] ?? [];
+            $direct    = GlobalCache::getDirectThrowsForKey($key);
             $annotated = GlobalCache::$annotatedThrows[$key] ?? [];
             $combined  = array_values(array_unique(array_merge($direct, $annotated)));
             sort($combined);

--- a/tests/Unit/ThrowsGathererTest.php
+++ b/tests/Unit/ThrowsGathererTest.php
@@ -53,9 +53,9 @@ class ThrowsGathererTest extends TestCase
         $traverser->traverse($ast);
 
         $key = 'T\\C::foo';
-        $this->assertArrayHasKey($key, GlobalCache::$directThrows);
+        $this->assertArrayHasKey($key, GlobalCache::getDirectThrows());
         // The thrown LogicException is caught within the method, so no direct throws should be reported
-        $this->assertSame([], GlobalCache::$directThrows[$key] ?? []);
+        $this->assertSame([], GlobalCache::getDirectThrowsForKey($key));
     }
 
     /**
@@ -83,10 +83,10 @@ class ThrowsGathererTest extends TestCase
         $traverser->traverse($ast);
 
         $key = 'T\\C::foo';
-        $this->assertArrayHasKey($key, GlobalCache::$directThrows);
+        $this->assertArrayHasKey($key, GlobalCache::getDirectThrows());
         $this->assertEqualsCanonicalizing(
             ['RuntimeException'],
-            GlobalCache::$directThrows[$key]
+            GlobalCache::getDirectThrowsForKey($key)
         );
     }
 
@@ -125,10 +125,10 @@ class ThrowsGathererTest extends TestCase
         $traverser->traverse($ast);
 
         $key = 'T\\C::foo';
-        $this->assertArrayHasKey($key, GlobalCache::$directThrows);
+        $this->assertArrayHasKey($key, GlobalCache::getDirectThrows());
         $this->assertEqualsCanonicalizing(
             ['Exception'],
-            GlobalCache::$directThrows[$key]
+            GlobalCache::getDirectThrowsForKey($key)
         );
     }
 
@@ -164,10 +164,10 @@ class ThrowsGathererTest extends TestCase
         $traverser->traverse($ast);
 
         $key = 'T\\C::foo';
-        $this->assertArrayHasKey($key, GlobalCache::$directThrows);
+        $this->assertArrayHasKey($key, GlobalCache::getDirectThrows());
         $this->assertEqualsCanonicalizing(
             ['RuntimeException', 'Throwable'],
-            GlobalCache::$directThrows[$key]
+            GlobalCache::getDirectThrowsForKey($key)
         );
         $origins = GlobalCache::getThrowOriginsForKey($key);
         $this->assertSame(
@@ -209,10 +209,10 @@ class ThrowsGathererTest extends TestCase
         $traverser->traverse($ast);
 
         $key = 'Pitfalls\\CatchRootException\\C::foo';
-        $this->assertArrayHasKey($key, GlobalCache::$directThrows);
+        $this->assertArrayHasKey($key, GlobalCache::getDirectThrows());
         $this->assertEqualsCanonicalizing(
             ['Exception'],
-            GlobalCache::$directThrows[$key]
+            GlobalCache::getDirectThrowsForKey($key)
         );
     }
 
@@ -249,8 +249,8 @@ class ThrowsGathererTest extends TestCase
         $traverser->traverse($ast);
 
         $key = 'Pitfalls\\CatchParentException\\C::foo';
-        $this->assertArrayHasKey($key, GlobalCache::$directThrows);
-        $this->assertSame([], GlobalCache::$directThrows[$key]);
+        $this->assertArrayHasKey($key, GlobalCache::getDirectThrows());
+        $this->assertSame([], GlobalCache::getDirectThrowsForKey($key));
     }
 
     /**
@@ -284,8 +284,8 @@ class ThrowsGathererTest extends TestCase
         $traverser->traverse($ast);
 
         $key = 'Pitfalls\\CatchParentSameFile\\C::foo';
-        $this->assertArrayHasKey($key, GlobalCache::$directThrows);
-        $this->assertSame([], GlobalCache::$directThrows[$key]);
+        $this->assertArrayHasKey($key, GlobalCache::getDirectThrows());
+        $this->assertSame([], GlobalCache::getDirectThrowsForKey($key));
     }
 
     /**
@@ -314,7 +314,7 @@ class ThrowsGathererTest extends TestCase
         $traverser->traverse($ast);
 
         $key = 'T\\C::foo';
-        $this->assertArrayHasKey($key, GlobalCache::$directThrows);
-        $this->assertEquals(['RuntimeException'], GlobalCache::$directThrows[$key]);
+        $this->assertArrayHasKey($key, GlobalCache::getDirectThrows());
+        $this->assertEquals(['RuntimeException'], GlobalCache::getDirectThrowsForKey($key));
     }
 }

--- a/tests/Unit/TraceCallSitesTest.php
+++ b/tests/Unit/TraceCallSitesTest.php
@@ -35,7 +35,7 @@ class TraceCallSitesTest extends TestCase
         $tr1->traverse($ast);
 
         foreach (array_keys(GlobalCache::getAstNodeMap()) as $key) {
-            $direct    = GlobalCache::$directThrows[$key] ?? [];
+            $direct    = GlobalCache::getDirectThrowsForKey($key);
             $annotated = GlobalCache::$annotatedThrows[$key] ?? [];
             $combined  = array_values(array_unique(array_merge($direct, $annotated)));
             sort($combined);

--- a/tests/Unit/TraceOriginsTest.php
+++ b/tests/Unit/TraceOriginsTest.php
@@ -35,7 +35,7 @@ class TraceOriginsTest extends TestCase
         $tr1->traverse($ast);
 
         foreach (array_keys(GlobalCache::getAstNodeMap()) as $key) {
-            $direct    = GlobalCache::$directThrows[$key] ?? [];
+            $direct    = GlobalCache::getDirectThrowsForKey($key);
             $annotated = GlobalCache::$annotatedThrows[$key] ?? [];
             $combined  = array_values(array_unique(array_merge($direct, $annotated)));
             sort($combined);

--- a/tests/Unit/UseMapTest.php
+++ b/tests/Unit/UseMapTest.php
@@ -286,4 +286,33 @@ class UseMapTest extends TestCase
         foreach ($expected as $k => $v) { sort($v); $expected[$k] = $v; }
         $this->assertSame($expected, $map);
     }
+
+    /**
+     * @throws \LogicException
+     */
+    public function testThrowsGathererCachesDirectThrows(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace NS;
+        function foo(){ throw new \RuntimeException(); }
+        function bar(){}
+        PHP;
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code) ?: [];
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new ThrowsGatherer($this->finder, $this->utils, 'dtfile.php'));
+        $traverser->traverse($ast);
+
+        $expected = [
+            'NS\\foo' => ['RuntimeException'],
+            'NS\\bar' => [],
+        ];
+        $map = GlobalCache::getDirectThrows();
+        ksort($map);
+        foreach ($map as $k => $v) { sort($v); $map[$k] = $v; }
+        ksort($expected);
+        foreach ($expected as $k => $v) { sort($v); $expected[$k] = $v; }
+        $this->assertSame($expected, $map);
+    }
 }


### PR DESCRIPTION
## Summary
- add public API for directThrows in GlobalCache
- update Application and ThrowsGatherer to call new methods
- modify tests to use the API
- add new test for getting directThrows

## Testing
- `./vendor/bin/phpunit`
- `./vendor/bin/psalm --no-cache`

------
https://chatgpt.com/codex/tasks/task_e_685aa9409c5483289850e57eeb1a7593