### PR TITLE
Add getters for original descriptions

### DIFF
--- a/src/DocBlockUpdater.php
+++ b/src/DocBlockUpdater.php
@@ -159,7 +159,7 @@ class DocBlockUpdater extends NodeVisitorAbstract
         $analyzedThrowsFqcns = array_values($analyzedThrowsFqcns);
         sort($analyzedThrowsFqcns);
         $docCommentNode = $node->getDocComment();
-        $originalNodeDescriptions = \HenkPoley\DocBlockDoctor\GlobalCache::$originalDescriptions[$nodeKey] ?? [];
+        $originalNodeDescriptions = \HenkPoley\DocBlockDoctor\GlobalCache::getOriginalDescriptionsForKey($nodeKey);
 
         /** @var list<string> $newDocBlockContentLines */
         $newDocBlockContentLines = [];

--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -27,7 +27,7 @@ class GlobalCache
     /**
      * @var array<string, array<string, string>>
      */
-    public static array $originalDescriptions = [];
+    private static array $originalDescriptions = [];
 
     /**
      * @var array<string, string>
@@ -160,6 +160,28 @@ class GlobalCache
     public static function addAnnotatedThrow(string $key, string $exception): void
     {
         self::$annotatedThrows[$key][] = $exception;
+    }
+
+    /**
+     * @return array<string, array<string,string>>
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public static function getOriginalDescriptions(): array
+    {
+        return self::$originalDescriptions;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public static function getOriginalDescriptionsForKey(string $key): array
+    {
+        return self::$originalDescriptions[$key] ?? [];
+    }
+
+    public static function setOriginalDescription(string $key, string $exception, string $text): void
+    {
+        self::$originalDescriptions[$key][$exception] = $text;
     }
 
     /**

--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -142,7 +142,7 @@ class ThrowsGatherer extends NodeVisitorAbstract
         \HenkPoley\DocBlockDoctor\GlobalCache::setAstNode($key, $node);
         \HenkPoley\DocBlockDoctor\GlobalCache::setFilePathForKey($key, $this->filePath);
         \HenkPoley\DocBlockDoctor\GlobalCache::setDirectThrowsForKey($key, []);
-        \HenkPoley\DocBlockDoctor\GlobalCache::$originalDescriptions[$key] = [];
+        $originalDescriptionsForKey = \HenkPoley\DocBlockDoctor\GlobalCache::getOriginalDescriptionsForKey($key);
         $currentAnnotatedThrowsFqcns = [];
 
         $docComment = $node->getDocComment();
@@ -166,8 +166,18 @@ class ThrowsGatherer extends NodeVisitorAbstract
                 $contentLine = rtrim((string)$contentLine);
 
                 if (preg_match('/^@throws\s+([^\s]+)\s*(.*)/i', $contentLine, $matches)) {
-                    if ($currentThrowsFqcnForDesc !== null && $currentThrowsFqcnForDesc !== '' && !isset(\HenkPoley\DocBlockDoctor\GlobalCache::$originalDescriptions[$key][$currentThrowsFqcnForDesc]) && !in_array(trim($accumulatedDescription), ['', '0'], true)) {
-                        \HenkPoley\DocBlockDoctor\GlobalCache::$originalDescriptions[$key][$currentThrowsFqcnForDesc] = trim($accumulatedDescription);
+                    if (
+                        $currentThrowsFqcnForDesc !== null &&
+                        $currentThrowsFqcnForDesc !== '' &&
+                        !isset($originalDescriptionsForKey[$currentThrowsFqcnForDesc]) &&
+                        !in_array(trim($accumulatedDescription), ['', '0'], true)
+                    ) {
+                        \HenkPoley\DocBlockDoctor\GlobalCache::setOriginalDescription(
+                            $key,
+                            $currentThrowsFqcnForDesc,
+                            trim($accumulatedDescription)
+                        );
+                        $originalDescriptionsForKey[$currentThrowsFqcnForDesc] = trim($accumulatedDescription);
                     }
                     $exceptionNameInAnnotation = trim($matches[1]);
                     $resolvedFqcnForAnnotation = $this->astUtils->resolveStringToFqcn($exceptionNameInAnnotation, $this->currentNamespace, $this->useMap);
@@ -180,15 +190,35 @@ class ThrowsGatherer extends NodeVisitorAbstract
                 } elseif ($currentThrowsFqcnForDesc !== null && $currentThrowsFqcnForDesc !== '' && !$isFirstLine && !$isLastLine && !preg_match('/^@\w+/', $contentLine)) {
                     $accumulatedDescription .= (in_array(trim($accumulatedDescription), ['', '0'], true) && $contentLine === '' ? '' : "\n") . $contentLine;
                 } elseif ($isLastLine || preg_match('/^@\w+/', $contentLine)) {
-                    if ($currentThrowsFqcnForDesc !== null && $currentThrowsFqcnForDesc !== '' && !in_array(trim($accumulatedDescription), ['', '0'], true) && !isset(\HenkPoley\DocBlockDoctor\GlobalCache::$originalDescriptions[$key][$currentThrowsFqcnForDesc])) {
-                        \HenkPoley\DocBlockDoctor\GlobalCache::$originalDescriptions[$key][$currentThrowsFqcnForDesc] = trim($accumulatedDescription);
+                    if (
+                        $currentThrowsFqcnForDesc !== null &&
+                        $currentThrowsFqcnForDesc !== '' &&
+                        !in_array(trim($accumulatedDescription), ['', '0'], true) &&
+                        !isset($originalDescriptionsForKey[$currentThrowsFqcnForDesc])
+                    ) {
+                        \HenkPoley\DocBlockDoctor\GlobalCache::setOriginalDescription(
+                            $key,
+                            $currentThrowsFqcnForDesc,
+                            trim($accumulatedDescription)
+                        );
+                        $originalDescriptionsForKey[$currentThrowsFqcnForDesc] = trim($accumulatedDescription);
                     }
                     $currentThrowsFqcnForDesc = null;
                     $accumulatedDescription = '';
                 }
             }
-            if ($currentThrowsFqcnForDesc !== null && $currentThrowsFqcnForDesc !== '' && !in_array(trim($accumulatedDescription), ['', '0'], true) && !isset(\HenkPoley\DocBlockDoctor\GlobalCache::$originalDescriptions[$key][$currentThrowsFqcnForDesc])) {
-                \HenkPoley\DocBlockDoctor\GlobalCache::$originalDescriptions[$key][$currentThrowsFqcnForDesc] = trim($accumulatedDescription);
+            if (
+                $currentThrowsFqcnForDesc !== null &&
+                $currentThrowsFqcnForDesc !== '' &&
+                !in_array(trim($accumulatedDescription), ['', '0'], true) &&
+                !isset($originalDescriptionsForKey[$currentThrowsFqcnForDesc])
+            ) {
+                \HenkPoley\DocBlockDoctor\GlobalCache::setOriginalDescription(
+                    $key,
+                    $currentThrowsFqcnForDesc,
+                    trim($accumulatedDescription)
+                );
+                $originalDescriptionsForKey[$currentThrowsFqcnForDesc] = trim($accumulatedDescription);
             }
         }
         \HenkPoley\DocBlockDoctor\GlobalCache::setAnnotatedThrowsForKey(


### PR DESCRIPTION
## Summary
- make the original descriptions cache private
- expose helper methods to read and write original descriptions
- use the new methods across the codebase
- test caching of original descriptions

## Testing
- `./vendor/bin/phpunit`
- `./vendor/bin/psalm --no-cache --no-progress`


------
https://chatgpt.com/codex/tasks/task_e_685aae0ab4888328b53f9bb859594cc7