### PR TITLE
Add throw origins accessors and tests

### DIFF
--- a/src/DocBlockUpdater.php
+++ b/src/DocBlockUpdater.php
@@ -235,7 +235,7 @@ class DocBlockUpdater extends NodeVisitorAbstract
                 // tombstone("ERROR: NoValue - src/DocBlockUpdater.php:188:46 - All possible types for this assignment were invalidated - This may be dead code (see https://psalm.dev/179)");
                 $fqcnWithBackslash = '\\' . ltrim($fqcn, '\\');
                 if ($this->traceOrigins) {
-                    $originChains = \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$nodeKey][$fqcn] ?? [];
+                    $originChains = \HenkPoley\DocBlockDoctor\GlobalCache::getThrowOriginsForKey($nodeKey)[$fqcn] ?? [];
                     $cleaned = [];
                     foreach ($originChains as $ch) {
                         if (strpos($ch, $nodeKey . ' <- ') === 0) {
@@ -247,7 +247,7 @@ class DocBlockUpdater extends NodeVisitorAbstract
                     }
                     $description = implode(', ', $cleaned);
                 } elseif ($this->traceCallSites) {
-                    $originChains = \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$nodeKey][$fqcn] ?? [];
+                    $originChains = \HenkPoley\DocBlockDoctor\GlobalCache::getThrowOriginsForKey($nodeKey)[$fqcn] ?? [];
                     $lines = [];
                     foreach ($originChains as $ch) {
                         if (strpos($ch, $nodeKey . ' <- ') === 0) {

--- a/src/GlobalCache.php
+++ b/src/GlobalCache.php
@@ -78,7 +78,7 @@ class GlobalCache
      *     thrown. Example:
      *     "src/File.php:10 <- SomeClass::method <- Other::callee <- vendor/lib.php:5".
      */
-    public static array $throwOrigins = [];
+    private static array $throwOrigins = [];
 
     public static function clear(): void
     {
@@ -217,11 +217,41 @@ class GlobalCache
     }
 
     /**
+     * @return array<string, array<string,string[]>>
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public static function getThrowOrigins(): array
+    {
+        return self::$throwOrigins;
+    }
+
+    /**
      * @return array<string, string[]>
      */
     public static function getThrowOriginsForKey(string $key): array
     {
         return self::$throwOrigins[$key] ?? [];
+    }
+
+    /**
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public static function addThrowOrigin(string $key, string $exception, string $chain): void
+    {
+        if (!isset(self::$throwOrigins[$key][$exception])) {
+            self::$throwOrigins[$key][$exception] = [];
+        }
+        if (!in_array($chain, self::$throwOrigins[$key][$exception], true) && count(self::$throwOrigins[$key][$exception]) < self::MAX_ORIGIN_CHAINS) {
+            self::$throwOrigins[$key][$exception][] = $chain;
+        }
+    }
+
+    /**
+     * @param array<string,string[]> $origins
+     */
+    public static function setThrowOriginsForKey(string $key, array $origins): void
+    {
+        self::$throwOrigins[$key] = $origins;
     }
 
     /**

--- a/src/ThrowsGatherer.php
+++ b/src/ThrowsGatherer.php
@@ -268,9 +268,6 @@ class ThrowsGatherer extends NodeVisitorAbstract
             return [];
         }
         $throwNodes = $this->nodeFinder->findInstanceOf($funcOrMethodNode->stmts, Node\Expr\Throw_::class);
-        if (!isset(\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey])) {
-            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey] = [];
-        }
         foreach ($throwNodes as $throwExpr) {
             // Skip throws that are unreachable due to a prior throw/return
             // statement in the current statement list.
@@ -355,13 +352,16 @@ class ThrowsGatherer extends NodeVisitorAbstract
             static fn(string $fqcn): bool => AstUtils::classOrInterfaceExistsNoAutoload($fqcn)
         );
 
-        foreach (\HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey] as $ex => $origins) {
+        $originsForKey = \HenkPoley\DocBlockDoctor\GlobalCache::getThrowOriginsForKey($funcKey);
+        foreach ($originsForKey as $ex => $origins) {
             $origins = array_values(array_unique($origins));
             if (count($origins) > \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS) {
                 $origins = array_slice($origins, 0, \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS);
             }
-            \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$ex] = $origins;
+            $originsForKey[$ex] = $origins;
         }
+
+        \HenkPoley\DocBlockDoctor\GlobalCache::setThrowOriginsForKey($funcKey, $originsForKey);
 
         return array_values(array_unique($filtered));
     }
@@ -498,11 +498,13 @@ class ThrowsGatherer extends NodeVisitorAbstract
         $fqcns[] = $fqcn;
         $loc = $this->filePath . ':' . $throwExpr->getStartLine();
         $chain = $funcKey . ' <- ' . $loc;
-        $origins = \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fqcn] ?? [];
+        $all = \HenkPoley\DocBlockDoctor\GlobalCache::getThrowOriginsForKey($funcKey);
+        $origins = $all[$fqcn] ?? [];
         if (!in_array($chain, $origins, true) && count($origins) < \HenkPoley\DocBlockDoctor\GlobalCache::MAX_ORIGIN_CHAINS) {
             $origins[] = $chain;
         }
-        \HenkPoley\DocBlockDoctor\GlobalCache::$throwOrigins[$funcKey][$fqcn] = $origins;
+        $all[$fqcn] = $origins;
+        \HenkPoley\DocBlockDoctor\GlobalCache::setThrowOriginsForKey($funcKey, $all);
     }
 
     /**

--- a/tests/Unit/CallCatchPropagationTest.php
+++ b/tests/Unit/CallCatchPropagationTest.php
@@ -57,14 +57,13 @@ class CallCatchPropagationTest extends TestCase
             $combined  = array_values(array_unique(array_merge($direct, $annotated)));
             sort($combined);
             GlobalCache::setResolvedThrowsForKey($key, $combined);
-            if (!isset(GlobalCache::$throwOrigins[$key])) {
-                GlobalCache::$throwOrigins[$key] = [];
-            }
+            $origins = GlobalCache::getThrowOriginsForKey($key);
             foreach ($combined as $ex) {
-                if (!isset(GlobalCache::$throwOrigins[$key][$ex])) {
-                    GlobalCache::$throwOrigins[$key][$ex] = [];
+                if (!isset($origins[$ex])) {
+                    $origins[$ex] = [];
                 }
             }
+            GlobalCache::setThrowOriginsForKey($key, $origins);
         }
 
         foreach (GlobalCache::getAstNodeMap() as $funcKey => $funcNode) {

--- a/tests/Unit/DocBlockUpdaterPatchTest.php
+++ b/tests/Unit/DocBlockUpdaterPatchTest.php
@@ -49,9 +49,11 @@ class DocBlockUpdaterPatchTest extends TestCase
             GlobalCache::setResolvedThrowsForKey($key, $vals);
         }
         foreach ($throwOrigins as $fn => $exMap) {
+            $map = [];
             foreach ($exMap as $ex => $chains) {
-                GlobalCache::$throwOrigins[$fn][$ex] = $chains;
+                $map[$ex] = $chains;
             }
+            GlobalCache::setThrowOriginsForKey($fn, $map);
         }
 
         $tr2 = new NodeTraverser();


### PR DESCRIPTION
## Summary
- make throw origins cache private
- add accessor and mutator methods for throw origins
- use new methods across codebase
- add comprehensive throw origins cache test

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml --stop-on-failure`
- `vendor/bin/psalm --no-progress`

------
https://chatgpt.com/codex/tasks/task_e_685ab21ef31c8328abc51aa4bb99e60b