### PR TITLE
Improve test coverage

### DIFF
--- a/tests/Unit/ApplicationRunTest.php
+++ b/tests/Unit/ApplicationRunTest.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\Tests\Unit;
+
+use HenkPoley\DocBlockDoctor\Application;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationRunTest extends TestCase
+{
+    public function testRunOutputsHelpAndReturnsZero(): void
+    {
+        $app = new Application();
+        ob_start();
+        $result = $app->run(['doc-block-doctor', '--help']);
+        $output = ob_get_clean();
+
+        $this->assertSame(0, $result);
+        $this->assertStringContainsString('Usage:', $output);
+        $this->assertStringContainsString('--help', $output);
+    }
+}

--- a/tests/Unit/ApplicationStoreResolvedDataTest.php
+++ b/tests/Unit/ApplicationStoreResolvedDataTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\Tests\Unit;
+
+use HenkPoley\DocBlockDoctor\Application;
+use HenkPoley\DocBlockDoctor\GlobalCache;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationStoreResolvedDataTest extends TestCase
+{
+    private function invokeStore(string $key, array $throws, array $origins): bool
+    {
+        $app = new Application();
+        $ref = new \ReflectionMethod(Application::class, 'storeResolvedData');
+        $ref->setAccessible(true);
+        /** @var bool $res */
+        $res = $ref->invoke($app, $key, $throws, $origins);
+        return $res;
+    }
+
+    public function testStoreResolvedDataUpdatesCacheWhenDifferent(): void
+    {
+        GlobalCache::clear();
+        GlobalCache::setResolvedThrowsForKey('foo', ['RuntimeException']);
+        GlobalCache::setThrowOriginsForKey('foo', ['RuntimeException' => []]);
+
+        $changed = $this->invokeStore('foo', ['LogicException'], ['LogicException' => []]);
+
+        $this->assertTrue($changed);
+        $this->assertSame(['LogicException'], GlobalCache::getResolvedThrowsForKey('foo'));
+    }
+
+    public function testStoreResolvedDataReturnsFalseWhenUnchanged(): void
+    {
+        GlobalCache::clear();
+        GlobalCache::setResolvedThrowsForKey('bar', ['RuntimeException']);
+        GlobalCache::setThrowOriginsForKey('bar', ['RuntimeException' => []]);
+
+        $changed = $this->invokeStore('bar', ['RuntimeException'], ['RuntimeException' => []]);
+
+        $this->assertFalse($changed);
+        $this->assertSame(['RuntimeException'], GlobalCache::getResolvedThrowsForKey('bar'));
+    }
+}


### PR DESCRIPTION
## Summary
- add regression tests for `Application::run` help mode and `storeResolvedData`
- show how to generate HTML coverage output

## Testing
- `./vendor/bin/phpunit`
- `./vendor/bin/phpunit --coverage-text --show-uncovered-for-coverage-text`

------
https://chatgpt.com/codex/tasks/task_e_685ab9a208048328b0999ac14288c70a