### PR TITLE
Improve coverage of docblock utilities

### DIFF
--- a/tests/Unit/DocBlockUpdaterUtilitiesTest.php
+++ b/tests/Unit/DocBlockUpdaterUtilitiesTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace HenkPoley\DocBlockDoctor\Tests\Unit;
+
+use HenkPoley\DocBlockDoctor\AstUtils;
+use HenkPoley\DocBlockDoctor\DocBlockUpdater;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Function_;
+use PHPUnit\Framework\TestCase;
+
+class DocBlockUpdaterUtilitiesTest extends TestCase
+{
+    public function testSplitDocLines(): void
+    {
+        $utils = new AstUtils();
+        $updater = new DocBlockUpdater($utils, 'dummy.php', false, false, true);
+        $ref = new \ReflectionMethod(DocBlockUpdater::class, 'splitDocLines');
+        $ref->setAccessible(true);
+        $doc = "/**\n * Foo\n * Bar\n */";
+        $result = $ref->invoke($updater, $doc);
+        $this->assertSame(['', 'Foo', 'Bar', ''], $result);
+    }
+
+    public function testGetNodeSignatureForMessage(): void
+    {
+        $utils = $this->createMock(AstUtils::class);
+        $utils->method('getNodeKey')->willReturn('foo');
+        $fn = new Function_('foo');
+        $updater = new DocBlockUpdater($utils, 'dummy.php', false, false, true);
+        $ref = new \ReflectionMethod(DocBlockUpdater::class, 'getNodeSignatureForMessage');
+        $ref->setAccessible(true);
+        $this->assertSame('foo', $ref->invoke($updater, $fn));
+
+        $utils2 = $this->createMock(AstUtils::class);
+        $utils2->method('getNodeKey')->willReturn('');
+        $fn2 = new Function_('bar');
+        $updater2 = new DocBlockUpdater($utils2, 'dummy.php', false, false, true);
+        $ref2 = new \ReflectionMethod(DocBlockUpdater::class, 'getNodeSignatureForMessage');
+        $ref2->setAccessible(true);
+        $this->assertSame('bar()', $ref2->invoke($updater2, $fn2));
+
+        $utils3 = $this->createMock(AstUtils::class);
+        $utils3->method('getNodeKey')->willReturn(null);
+        $node = $this->createMock(Node::class);
+        $updater3 = new DocBlockUpdater($utils3, 'dummy.php', false, false, true);
+        $ref3 = new \ReflectionMethod(DocBlockUpdater::class, 'getNodeSignatureForMessage');
+        $ref3->setAccessible(true);
+        $this->assertSame('unknown_node_type', $ref3->invoke($updater3, $node));
+    }
+
+    public function testNormalizeDocBlockStringEmptyReturnsNull(): void
+    {
+        $utils = new AstUtils();
+        $updater = new DocBlockUpdater($utils, 'dummy.php', false, false, true);
+        $ref = new \ReflectionMethod(DocBlockUpdater::class, 'normalizeDocBlockString');
+        $ref->setAccessible(true);
+        $this->assertNull($ref->invoke($updater, " \n \n"));
+    }
+}

--- a/tests/Unit/UseStatementSimplifierSurgicalTest.php
+++ b/tests/Unit/UseStatementSimplifierSurgicalTest.php
@@ -6,6 +6,7 @@ use HenkPoley\DocBlockDoctor\UseStatementSimplifierSurgical;
 use PhpParser\ParserFactory;
 use PhpParser\PhpVersion;
 use PhpParser\NodeTraverser;
+use PhpParser\PrettyPrinter;
 use PHPUnit\Framework\TestCase;
 
 class UseStatementSimplifierSurgicalTest extends TestCase
@@ -58,5 +59,53 @@ class UseStatementSimplifierSurgicalTest extends TestCase
         }
 
         $this->assertStringContainsString('use Foo\\Bar\\Baz as Qux;', $newCode);
+    }
+
+    public function testPrinterPrefixStrippedAndNewlineAdded(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        use Foo\Bar\{Baz};
+        class C {}
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code) ?: [];
+        $traverser = new NodeTraverser();
+        $visitor = new UseStatementSimplifierSurgical();
+        $traverser->addVisitor($visitor);
+
+        $printer = new class extends PrettyPrinter\Standard {
+            public function prettyPrint(array $stmts): string
+            {
+                return "<?php use Foo\\Bar\\Baz;"; // no newline and with <?php prefix
+            }
+        };
+        $ref = new \ReflectionProperty(UseStatementSimplifierSurgical::class, 'printer');
+        $ref->setAccessible(true);
+        $ref->setValue($visitor, $printer);
+
+        $traverser->traverse($ast);
+
+        $patch = $visitor->pendingPatches[0] ?? null;
+        $this->assertNotNull($patch);
+        $this->assertSame("use Foo\\Bar\\Baz;\n", $patch['replacementText']);
+    }
+
+    public function testNoPatchForMultipleGroupUse(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        use Foo\Bar\{Baz, Qux};
+        class C {}
+        PHP;
+
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 4));
+        $ast = $parser->parse($code) ?: [];
+        $traverser = new NodeTraverser();
+        $visitor = new UseStatementSimplifierSurgical();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+        $this->assertSame([], $visitor->pendingPatches);
     }
 }


### PR DESCRIPTION
## Summary
- add more DocBlockUpdater tests
- extend UseStatementSimplifierSurgical tests

## Testing
- `./vendor/bin/phpunit --testsuite Unit`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685abbeecbdc8328a02996ff016fbee4